### PR TITLE
Show severity levels for pagerduty analysis and show users without incidents

### DIFF
--- a/frontend/src/components/dashboard/TeamMembersList.tsx
+++ b/frontend/src/components/dashboard/TeamMembersList.tsx
@@ -206,8 +206,7 @@ export function TeamMembersList({
             
             // Filter members with valid scores
             const validMembers = allMembers.filter((member) => {
-              // Only include members with CBI scores
-              return member.cbi_score !== undefined && member.cbi_score !== null && member.cbi_score > 0
+              return member.cbi_score !== undefined && member.cbi_score !== null
             })
             
             // Separate members with and without incidents


### PR DESCRIPTION
Show Pagerduty severity levels
  - Added "priorities" to PagerDuty API includes to ensure priority data is fetched
  - Fixed unified analyzer to use pre-mapped severity from PagerDuty client
  - Added comprehensive P1-P5 priority mapping
  - Enhanced frontend to show severity breakdown for both Rootly and PagerDuty analyses
  - Added debug logging for severity mapping
  - Ensured no fake/generated data is displayed

