### PR TITLE
Team Members Tab: Auto-display synced Slack users with survey counts

### DIFF
--- a/backend/app/api/endpoints/rootly.py
+++ b/backend/app/api/endpoints/rootly.py
@@ -1549,7 +1549,7 @@ async def get_synced_users(
                 # Continue without on-call status
 
         # Get survey counts for all users in this organization
-        from app.models.survey_response import UserBurnoutReport
+        from app.models.user_burnout_report import UserBurnoutReport
         survey_counts = {}
         for corr in correlations:
             if corr.user_id:

--- a/backend/app/api/endpoints/rootly.py
+++ b/backend/app/api/endpoints/rootly.py
@@ -1548,6 +1548,16 @@ async def get_synced_users(
                 logger.error(traceback.format_exc())
                 # Continue without on-call status
 
+        # Get survey counts for all users in this organization
+        from app.models.survey_response import UserBurnoutReport
+        survey_counts = {}
+        for corr in correlations:
+            if corr.user_id:
+                count = db.query(func.count(UserBurnoutReport.id)).filter(
+                    UserBurnoutReport.user_id == corr.user_id
+                ).scalar() or 0
+                survey_counts[corr.id] = count
+
         # Format the response
         synced_users = []
         for corr in correlations:
@@ -1579,6 +1589,7 @@ async def get_synced_users(
                 "jira_account_id": corr.jira_account_id,
                 "jira_email": corr.jira_email,
                 "is_oncall": is_oncall,
+                "survey_count": survey_counts.get(corr.id, 0),
                 "created_at": corr.created_at.isoformat() if corr.created_at else None
             })
 

--- a/frontend/src/app/integrations/components/SurveyFeedbackSection.tsx
+++ b/frontend/src/app/integrations/components/SurveyFeedbackSection.tsx
@@ -14,6 +14,7 @@ interface SurveyFeedbackSectionProps {
   teamMembers: any[]
   loadingTeamMembers: boolean
   loadingSyncedUsers: boolean
+  syncedUsers: any[]
   fetchTeamMembers: () => void
   syncUsersToCorrelation: () => void
   fetchSyncedUsers: () => void
@@ -36,6 +37,7 @@ export function SurveyFeedbackSection({
   teamMembers,
   loadingTeamMembers,
   loadingSyncedUsers,
+  syncedUsers,
   fetchTeamMembers,
   syncUsersToCorrelation,
   fetchSyncedUsers,
@@ -61,6 +63,7 @@ export function SurveyFeedbackSection({
           teamMembers={teamMembers}
           loadingTeamMembers={loadingTeamMembers}
           loadingSyncedUsers={loadingSyncedUsers}
+          syncedUsers={syncedUsers}
           fetchTeamMembers={fetchTeamMembers}
           syncUsersToCorrelation={syncUsersToCorrelation}
           fetchSyncedUsers={fetchSyncedUsers}

--- a/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
+++ b/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
@@ -20,6 +20,7 @@ interface UnifiedSlackCardProps {
   teamMembers: any[]
   loadingTeamMembers: boolean
   loadingSyncedUsers: boolean
+  syncedUsers: any[]
   fetchTeamMembers: () => void
   syncUsersToCorrelation: () => void
   fetchSyncedUsers: () => void
@@ -55,6 +56,7 @@ export function UnifiedSlackCard({
   teamMembers,
   loadingTeamMembers,
   loadingSyncedUsers,
+  syncedUsers,
   fetchTeamMembers,
   syncUsersToCorrelation,
   fetchSyncedUsers,
@@ -486,6 +488,7 @@ export function UnifiedSlackCard({
                   teamMembers={teamMembers}
                   loadingTeamMembers={loadingTeamMembers}
                   loadingSyncedUsers={loadingSyncedUsers}
+                  syncedUsers={syncedUsers}
                   userInfo={userInfo}
                   fetchTeamMembers={fetchTeamMembers}
                   syncUsersToCorrelation={syncUsersToCorrelation}

--- a/frontend/src/app/integrations/handlers/team-handlers.ts
+++ b/frontend/src/app/integrations/handlers/team-handlers.ts
@@ -230,7 +230,8 @@ export async function fetchSyncedUsers(
   setSavedRecipients?: (recipients: Set<number>) => void,
   cache?: Map<string, any[]>,
   forceRefresh: boolean = false,
-  recipientsCache?: Map<string, Set<number>>
+  recipientsCache?: Map<string, Set<number>>,
+  openDrawer: boolean = true
 ): Promise<void> {
   if (!selectedOrganization) {
     toast.error('Please select an organization first')
@@ -242,7 +243,9 @@ export async function fetchSyncedUsers(
     const cachedUsers = cache.get(selectedOrganization)!
     setSyncedUsers(cachedUsers)
     setShowSyncedUsers(true)
-    setTeamMembersDrawerOpen(true)
+    if (openDrawer) {
+      setTeamMembersDrawerOpen(true)
+    }
 
     // Restore cached recipients if available (validate IDs still exist)
     if (recipientsCache?.has(selectedOrganization) && setSelectedRecipients && setSavedRecipients) {
@@ -289,7 +292,9 @@ export async function fetchSyncedUsers(
       const users = data.users || []
       setSyncedUsers(users)
       setShowSyncedUsers(true)
-      setTeamMembersDrawerOpen(true)
+      if (openDrawer) {
+        setTeamMembersDrawerOpen(true)
+      }
 
       // Update cache
       if (cache) {

--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -1958,7 +1958,7 @@ export default function IntegrationsPage() {
   }
 
   // Fetch synced users from database
-  const fetchSyncedUsers = async (showToast = true, autoSync = true, forceRefresh = false) => {
+  const fetchSyncedUsers = async (showToast = true, autoSync = true, forceRefresh = false, openDrawer = true) => {
     return TeamHandlers.fetchSyncedUsers(
       selectedOrganization,
       setLoadingSyncedUsers,
@@ -1972,7 +1972,8 @@ export default function IntegrationsPage() {
       setSavedRecipients,
       syncedUsersCache.current,
       forceRefresh,
-      recipientsCache.current
+      recipientsCache.current,
+      openDrawer
     )
   }
 

--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -3099,6 +3099,7 @@ export default function IntegrationsPage() {
                 teamMembers={teamMembers}
                 loadingTeamMembers={loadingTeamMembers}
                 loadingSyncedUsers={loadingSyncedUsers}
+                syncedUsers={syncedUsers}
                 fetchTeamMembers={fetchTeamMembers}
                 syncUsersToCorrelation={syncUsersToCorrelation}
                 fetchSyncedUsers={fetchSyncedUsers}

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -309,8 +309,9 @@ export function SlackSurveyTabs({
           <div className="mb-4">
             <h4 className="font-medium text-gray-900 mb-2">Survey Correlation</h4>
             <p className="text-sm text-gray-600 mb-3">
-              When team members submit a <code className="bg-gray-100 px-1 rounded text-xs">/oncall-health</code>,
-              we match them to their profile using:
+              When team members run <code className="bg-gray-100 px-1 rounded text-xs">/oncall-health</code>,
+              it opens an interactive modal with 3 scored questions + optional text.
+              We match their responses to their profile using:
             </p>
             <div className="space-y-2 text-sm">
               <div className="flex items-start space-x-2">

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -310,7 +310,7 @@ export function SlackSurveyTabs({
             <h4 className="font-medium text-gray-900 mb-2">Survey Correlation</h4>
             <p className="text-sm text-gray-600 mb-3">
               When team members run <code className="bg-gray-100 px-1 rounded text-xs">/oncall-health</code>,
-              it opens an interactive modal with 3 scored questions + optional text.
+              it opens an interactive modal with 2 scored questions + optional text.
               We match their responses to their profile using:
             </p>
             <div className="space-y-2 text-sm">

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -2,11 +2,12 @@
 
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { CheckCircle, Users, Send, RefreshCw, Database, Users2, Loader2, Building, Clock } from "lucide-react"
+import { CheckCircle, Users, Send, RefreshCw, Database, Users2, Loader2, Building, Clock, Mail } from "lucide-react"
 
 interface SlackSurveyTabsProps {
   slackIntegration: any
@@ -15,6 +16,7 @@ interface SlackSurveyTabsProps {
   teamMembers: any[]
   loadingTeamMembers: boolean
   loadingSyncedUsers: boolean
+  syncedUsers: any[]
   userInfo: any
   fetchTeamMembers: () => void
   syncUsersToCorrelation: () => void
@@ -44,6 +46,7 @@ export function SlackSurveyTabs({
   teamMembers,
   loadingTeamMembers,
   loadingSyncedUsers,
+  syncedUsers,
   userInfo,
   fetchTeamMembers,
   syncUsersToCorrelation,
@@ -330,11 +333,61 @@ export function SlackSurveyTabs({
             </div>
           </div>
 
+          {/* Synced Users List */}
           {selectedOrganization && (
             <div className="border-t pt-4">
-              <div className="text-sm text-gray-600 text-center py-6">
-                <p>Use the <strong>Sync Members</strong> button at the top to load users from your organization.</p>
-              </div>
+              {loadingSyncedUsers ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="w-5 h-5 animate-spin text-gray-400 mr-2" />
+                  <span className="text-sm text-gray-600">Loading team members...</span>
+                </div>
+              ) : syncedUsers.length > 0 ? (
+                <div>
+                  <div className="flex items-center justify-between mb-3">
+                    <h5 className="text-sm font-medium text-gray-900">Synced Members ({syncedUsers.length})</h5>
+                  </div>
+                  <div className="max-h-[400px] overflow-y-auto space-y-2 pr-2">
+                    {syncedUsers.map((user: any) => (
+                      <div key={user.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="font-medium text-gray-900 truncate">{user.name}</span>
+                            {user.survey_count > 0 && (
+                              <Badge variant="secondary" className="text-xs bg-green-100 text-green-700 border-green-200">
+                                {user.survey_count} {user.survey_count === 1 ? 'survey' : 'surveys'}
+                              </Badge>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-1 text-xs text-gray-500">
+                            <Mail className="w-3 h-3" />
+                            <span className="truncate">{user.email}</span>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-1 ml-3">
+                          {user.platforms?.map((platform: string) => {
+                            const colors: Record<string, string> = {
+                              slack: 'bg-purple-100 text-purple-700',
+                              rootly: 'bg-blue-100 text-blue-700',
+                              pagerduty: 'bg-green-100 text-green-700',
+                              github: 'bg-gray-100 text-gray-700',
+                              jira: 'bg-indigo-100 text-indigo-700'
+                            }
+                            return (
+                              <Badge key={platform} variant="outline" className={`text-xs ${colors[platform] || 'bg-gray-100 text-gray-700'}`}>
+                                {platform}
+                              </Badge>
+                            )
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="text-sm text-gray-600 text-center py-6">
+                  <p>Use the <strong>Sync Members</strong> button at the top to load users from your organization.</p>
+                </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -342,53 +342,56 @@ export function SlackSurveyTabs({
                   <Loader2 className="w-5 h-5 animate-spin text-gray-400 mr-2" />
                   <span className="text-sm text-gray-600">Loading team members...</span>
                 </div>
-              ) : syncedUsers.length > 0 ? (
-                <div>
-                  <div className="flex items-center justify-between mb-3">
-                    <h5 className="text-sm font-medium text-gray-900">Synced Members ({syncedUsers.length})</h5>
-                  </div>
-                  <div className="max-h-[400px] overflow-y-auto space-y-2 pr-2">
-                    {syncedUsers.map((user: any) => (
-                      <div key={user.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
-                            <span className="font-medium text-gray-900 truncate">{user.name}</span>
-                            {user.survey_count > 0 && (
-                              <Badge variant="secondary" className="text-xs bg-green-100 text-green-700 border-green-200">
-                                {user.survey_count} {user.survey_count === 1 ? 'survey' : 'surveys'}
-                              </Badge>
-                            )}
+              ) : (() => {
+                const slackUsers = syncedUsers.filter((u: any) => u.slack_user_id)
+                return slackUsers.length > 0 ? (
+                  <div>
+                    <div className="flex items-center justify-between mb-3">
+                      <h5 className="text-sm font-medium text-gray-900">Synced Members ({slackUsers.length})</h5>
+                    </div>
+                    <div className="max-h-[400px] overflow-y-auto space-y-2 pr-2">
+                      {slackUsers.map((user: any) => (
+                        <div key={user.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 mb-1">
+                              <span className="font-medium text-gray-900 truncate">{user.name}</span>
+                              {user.survey_count > 0 && (
+                                <Badge variant="secondary" className="text-xs bg-green-100 text-green-700 border-green-200">
+                                  {user.survey_count} {user.survey_count === 1 ? 'survey' : 'surveys'}
+                                </Badge>
+                              )}
+                            </div>
+                            <div className="flex items-center gap-1 text-xs text-gray-500">
+                              <Mail className="w-3 h-3" />
+                              <span className="truncate">{user.email}</span>
+                            </div>
                           </div>
-                          <div className="flex items-center gap-1 text-xs text-gray-500">
-                            <Mail className="w-3 h-3" />
-                            <span className="truncate">{user.email}</span>
+                          <div className="flex items-center gap-1 ml-3">
+                            {user.platforms?.map((platform: string) => {
+                              const colors: Record<string, string> = {
+                                slack: 'bg-purple-100 text-purple-700',
+                                rootly: 'bg-blue-100 text-blue-700',
+                                pagerduty: 'bg-green-100 text-green-700',
+                                github: 'bg-gray-100 text-gray-700',
+                                jira: 'bg-indigo-100 text-indigo-700'
+                              }
+                              return (
+                                <Badge key={platform} variant="outline" className={`text-xs ${colors[platform] || 'bg-gray-100 text-gray-700'}`}>
+                                  {platform}
+                                </Badge>
+                              )
+                            })}
                           </div>
                         </div>
-                        <div className="flex items-center gap-1 ml-3">
-                          {user.platforms?.map((platform: string) => {
-                            const colors: Record<string, string> = {
-                              slack: 'bg-purple-100 text-purple-700',
-                              rootly: 'bg-blue-100 text-blue-700',
-                              pagerduty: 'bg-green-100 text-green-700',
-                              github: 'bg-gray-100 text-gray-700',
-                              jira: 'bg-indigo-100 text-indigo-700'
-                            }
-                            return (
-                              <Badge key={platform} variant="outline" className={`text-xs ${colors[platform] || 'bg-gray-100 text-gray-700'}`}>
-                                {platform}
-                              </Badge>
-                            )
-                          })}
-                        </div>
-                      </div>
-                    ))}
+                      ))}
+                    </div>
                   </div>
-                </div>
-              ) : (
-                <div className="text-sm text-gray-600 text-center py-6">
-                  <p>Use the <strong>Sync Members</strong> button at the top to load users from your organization.</p>
-                </div>
-              )}
+                ) : (
+                  <div className="text-sm text-gray-600 text-center py-6">
+                    <p>Use the <strong>Sync Members</strong> button at the top to load users from your organization.</p>
+                  </div>
+                )
+              })()}
             </div>
           )}
 

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -20,7 +20,7 @@ interface SlackSurveyTabsProps {
   userInfo: any
   fetchTeamMembers: () => void
   syncUsersToCorrelation: () => void
-  fetchSyncedUsers: () => void
+  fetchSyncedUsers: (showToast?: boolean, autoSync?: boolean, forceRefresh?: boolean, openDrawer?: boolean) => void
   setShowManualSurveyModal: (show: boolean) => void
   loadSlackPermissions: () => void
   toast: any
@@ -77,7 +77,8 @@ export function SlackSurveyTabs({
   // Auto-fetch synced users when component mounts or organization changes
   useEffect(() => {
     if (selectedOrganization) {
-      fetchSyncedUsers()
+      // Fetch users but don't open the drawer (showToast=false, autoSync=true, forceRefresh=false, openDrawer=false)
+      fetchSyncedUsers(false, true, false, false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedOrganization])

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -74,6 +74,14 @@ export function SlackSurveyTabs({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // Empty array - run once on mount
 
+  // Auto-fetch synced users when component mounts or organization changes
+  useEffect(() => {
+    if (selectedOrganization) {
+      fetchSyncedUsers()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedOrganization])
+
   // Poll schedule every 10 seconds to sync changes across admins (only when page is visible)
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -388,7 +396,7 @@ export function SlackSurveyTabs({
                   </div>
                 ) : (
                   <div className="text-sm text-gray-600 text-center py-6">
-                    <p>Use the <strong>Sync Members</strong> button at the top to load users from your organization.</p>
+                    <p>No Slack users found. Use the <strong>Sync Members</strong> button at the top to sync users from your organization.</p>
                   </div>
                 )
               })()}


### PR DESCRIPTION
## Summary
Improved the Team Members tab in the Slack integration to automatically display synced users with their survey submission counts, making it easier to see team engagement at a glance.

## Changes

### Backend
1. **Add survey count to API response** - Modified `/rootly/synced-users` endpoint to include `survey_count` for each user by querying the `user_burnout_reports` table
2. **Fix import path** - Corrected import from `app.models.survey_response` to `app.models.user_burnout_report`

### Frontend
1. **Display synced Slack users with survey counts** - Added scrollable list showing all Slack-connected users with green badges indicating how many surveys they've submitted
2. **Auto-fetch on tab load** - Added `useEffect` to automatically fetch and display synced users when Team Members tab opens (no manual sync button required)
3. **Filter to Slack users only** - Filter `syncedUsers` to show only users with `slack_user_id` populated (excludes non-Slack users)
4. **Prevent drawer from auto-opening** - Added `openDrawer` parameter to prevent team members drawer from opening during background auto-fetch (better UX)
5. **Update empty state message** - Changed from instructional to informative: "No Slack users found"
6. **Fix survey question count** - Corrected description from "3 scored questions" to "2 scored questions + optional text"
7. **Update command description** - Fixed `/oncall-health` description in Team Members tab to match actual behavior

## Test plan
- [x] Navigate to Integrations → Slack → Team Members tab
- [x] Verify synced Slack users appear automatically (no manual sync needed)
- [x] Verify survey counts display correctly with green badges
- [x] Verify only users with Slack accounts appear in list
- [x] Verify drawer doesn't open automatically on page load
- [x] Verify description shows "2 scored questions + optional text"
- [x] Verify empty state message when no Slack users exist

## Screenshots
Before: Required manual "Sync Members" button click
After: Users auto-load with survey counts displayed inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)