### PR TITLE
Preserve GitHub commit data when manual mappings override auto-detected mappings

### DIFF
--- a/backend/app/services/github_correlation_service.py
+++ b/backend/app/services/github_correlation_service.py
@@ -204,19 +204,28 @@ class GitHubCorrelationService:
             for row in manual_mappings:
                 email, username, created_at = row
                 email_lower = email.lower()
-                
+
+                # Check if there's an existing auto-detected mapping with data_points
+                existing_data_points = 0
+                for m in mappings:
+                    if m['email'].lower() == email_lower:
+                        existing_data_points = m.get('data_points', 0)
+                        break
+
                 # Remove any existing auto-detected mapping for this email
                 mappings = [m for m in mappings if m['email'].lower() != email_lower]
-                
-                # Add the manual mapping
+
+                # Add the manual mapping, preserving data_points from auto-detected mapping
                 mappings.append({
                     'email': email,
                     'username': username,
-                    'data_points': 0,  # Will be fetched when collecting data
+                    'data_points': existing_data_points,  # Preserve data from auto-detected mapping
                     'mapping_successful': True,
                     'created_at': created_at,
                     'source': 'manual'
                 })
+
+                self.logger.info(f"📝 [MANUAL_MAPPING] {email} → {username}: preserved data_points={existing_data_points}")
                 seen_emails.add(email_lower)
             
             conn.close()


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where manual GitHub username mappings were destroying commit data for all team members. When manual mappings from `user_mappings` overrode auto-detected mappings from `integration_mappings`, the code was hardcoding `data_points=0`, causing all members to show 0 commits even though real data existed.

## The Problem

### What Was Broken ❌
Team members showed **0 commits** on their member cards despite:
- ✅ `integration_mappings` table containing correct data (vishnu=54 commits, ahammed=84 commits)
- ✅ Timeline endpoint successfully fetching GitHub data
- ✅ Data collection phase completing without errors

### Root Cause
At line 215 of `github_correlation_service.py`, when processing manual mappings:

```python
# OLD CODE (BROKEN):
mappings.append({
    'email': email,
    'username': username,
    'data_points': 0,  # ❌ Will be fetched when collecting data
    'mapping_successful': True,
    'created_at': created_at,
    'source': 'manual'
})
```

**The comment was incorrect** - the data HAD already been fetched! Manual mappings were overwriting good data with zeros.

### Why This Affected Everyone
Database investigation revealed Spencer (user_id=1) had **21 manual GitHub mappings** created in July/August 2025 for all team members with GitHub usernames. Since manual mappings take precedence over auto-detected ones, this bug zeroed out commit data for the entire team.

## The Bug Flow

1. **Auto-detected mapping created** ✅
   - `integration_mappings` table stores: `vishnu.mohanan@bigbinary.com` → `vishnuMohanan01` with 54 data_points
   
2. **Manual mapping overrides** ✅
   - `user_mappings` has: `vishnu.mohanan@bigbinary.com` → `vishnuMohanan01`
   - Manual mappings take precedence (intended behavior)

3. **Data destroyed** ❌
   - Code removes auto-detected mapping (✅ correct)
   - But adds manual mapping with hardcoded `data_points: 0` (❌ wrong!)
   - Result: 54 commits → 0 commits

4. **Member card shows 0 commits** ❌
   - Correlation service uses `data_points` to populate `github_activity`
   - Member cards display 0 commits for everyone

## The Fix

Before removing the auto-detected mapping, **save its data_points value**. When adding the manual mapping, **preserve the data_points** instead of hardcoding 0:

```python
# NEW CODE (FIXED):
# Check if there's an existing auto-detected mapping with data_points
existing_data_points = 0
for m in mappings:
    if m['email'].lower() == email_lower:
        existing_data_points = m.get('data_points', 0)
        break

# Remove any existing auto-detected mapping for this email
mappings = [m for m in mappings if m['email'].lower() != email_lower]

# Add the manual mapping, preserving data_points from auto-detected mapping
mappings.append({
    'email': email,
    'username': username,
    'data_points': existing_data_points,  # ✅ Preserve data from auto-detected mapping
    'mapping_successful': True,
    'created_at': created_at,
    'source': 'manual'
})

self.logger.info(f"📝 [MANUAL_MAPPING] {email} → {username}: preserved data_points={existing_data_points}")
```

## What This Fixes

✅ **vishnu** will now show **54 commits** (not 0)
✅ **ahammed** will now show **84 commits** (not 0)
✅ All 19 team members with GitHub data will show **real commit counts**
✅ Manual mappings still take precedence for username corrections
✅ Added logging to track data preservation: `[MANUAL_MAPPING]`

## Impact

### Before (Production Bug)
```
vishnuMohanan01: 0 commits ❌
ahammednafih: 0 commits ❌
spencerhcheng: 0 commits ❌
... (all members showing 0)
```

### After (This Fix)
```
vishnuMohanan01: 54 commits ✅
ahammednafih: 84 commits ✅
spencerhcheng: 21 commits ✅
... (real data for all members)
```

## Database Evidence

```sql
-- integration_mappings has CORRECT data:
SELECT source_identifier, data_points_count FROM integration_mappings 
WHERE analysis_id = 757 AND target_platform = 'github';

vishnu.mohanan@bigbinary.com     | 54
ahammed.bk@bigbinary.com         | 84
spencer.cheng@rootly.com         | 21

-- But analysis.results shows 0 commits (before fix):
SELECT member -> 'github_activity' -> 'commits_count' FROM analyses 
WHERE id = 757;

0  ❌ (lost during correlation)
```

## Test Plan

1. ✅ Run analysis with team members who have both auto-detected and manual mappings
2. ✅ Verify member cards show real commit counts (not 0)
3. ✅ Check logs for `[MANUAL_MAPPING]` entries showing preserved data_points
4. ✅ Confirm manual username corrections still work (precedence maintained)

## Files Changed

- `backend/app/services/github_correlation_service.py` (lines 203-229)
  - Added data_points preservation logic before removing auto-detected mappings
  - Added `[MANUAL_MAPPING]` logging for debugging

## Why This Is Critical

This bug was **silently destroying all GitHub commit data** for teams using the platform. Members appeared to have no activity when they actually had significant contributions. This undermines the core value proposition of the burnout detection system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)