### PR TITLE
Fix text selection visibility on active tabs

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -119,3 +119,40 @@
 .scrollbar-dark::-webkit-scrollbar-thumb:hover {
   background-color: #9ca3af;
 }
+
+/* Global text selection styling - FORCE dark text on light background */
+*::selection {
+  background-color: rgb(191, 219, 254) !important;
+  color: rgb(30, 30, 38) !important;
+  -webkit-text-fill-color: rgb(30, 30, 38) !important;
+}
+
+*::-moz-selection {
+  background-color: rgb(191, 219, 254) !important;
+  color: rgb(30, 30, 38) !important;
+}
+
+/* Force selection on buttons and tab triggers with webkit override */
+button::selection,
+[role="tab"]::selection,
+.text-white::selection,
+[data-state="active"]::selection,
+[data-state="checked"]::selection,
+[data-selected-single="true"]::selection,
+[data-range-start="true"]::selection {
+  background-color: rgb(191, 219, 254) !important;
+  color: rgb(30, 30, 38) !important;
+  -webkit-text-fill-color: rgb(30, 30, 38) !important;
+  --tw-text-opacity: 1 !important;
+}
+
+button::-moz-selection,
+[role="tab"]::-moz-selection,
+.text-white::-moz-selection,
+[data-state="active"]::-moz-selection,
+[data-state="checked"]::-moz-selection,
+[data-selected-single="true"]::-moz-selection,
+[data-range-start="true"]::-moz-selection {
+  background-color: rgb(191, 219, 254) !important;
+  color: rgb(30, 30, 38) !important;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -22,6 +22,30 @@ export default function RootLayout({
 
   return (
     <html lang="en">
+      <head>
+        <style dangerouslySetInnerHTML={{__html: `
+          *::selection,
+          button::selection,
+          [role="tab"]::selection,
+          .text-white::selection,
+          [data-state="active"]::selection,
+          [data-state="checked"]::selection {
+            background-color: #BFDBFE !important;
+            color: #1E1E26 !important;
+            -webkit-text-fill-color: #1E1E26 !important;
+            --tw-text-opacity: 1 !important;
+          }
+          *::-moz-selection,
+          button::-moz-selection,
+          [role="tab"]::-moz-selection,
+          .text-white::-moz-selection,
+          [data-state="active"]::-moz-selection,
+          [data-state="checked"]::-moz-selection {
+            background-color: #BFDBFE !important;
+            color: #1E1E26 !important;
+          }
+        `}} />
+      </head>
       <body className={inter.className}>
         {gaMeasurementId && (
           <>

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-neutral-100 text-neutral-600 hover:bg-neutral-200 data-[state=active]:bg-purple-600 data-[state=active]:text-white data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-neutral-100 text-neutral-600 hover:bg-neutral-200 data-[state=active]:bg-purple-600 data-[state=active]:text-neutral-900 data-[state=active]:shadow selection:bg-blue-200 selection:text-neutral-900",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
Fixed white-on-white text selection issue where selected text was invisible in active tabs and other white text elements.

## Changes
- Changed active tab text color from `text-white` to `text-neutral-900` for better visibility
- Added comprehensive `::selection` CSS rules with `-webkit-text-fill-color` override
- Targeted data attributes (`[data-state="active"]`, `[data-state="checked"]`) for proper selection styling

## Test Plan
- [x] Select text in "Setup", "Team Members", "Send Survey" tabs - text is now visible
- [x] Select text in "How it works" section - text is now visible  
- [x] Selection shows dark text on light blue background