### PR TITLE
Fix tab text visibility

### DIFF
--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-neutral-100 text-neutral-600 hover:bg-neutral-200 data-[state=active]:bg-purple-600 data-[state=active]:text-white data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-neutral-100 text-neutral-600 hover:bg-neutral-200 data-[state=active]:bg-purple-600 data-[state=active]:text-neutral-900 data-[state=active]:shadow",
       className
     )}
     {...props}


### PR DESCRIPTION
Changed active tab text color from white to dark (text-neutral-900) so text is visible when selected.

One line change: `data-[state=active]:text-white` → `data-[state=active]:text-neutral-900`