### PR TITLE
Standardize after-hours definition to 9 AM - 5 PM

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cp backend/.env.example backend/.env
 ```
 
 <details>
-<summary><b><img src="frontend/public/images/google-logo.png" width="16" height="16" alt="Google"> Instructions to get token for Google Auth</b></summary>
+<summary><b><img src="frontend/public/images/google-logo.png" width="16" height="16" alt="Google"> Google Auth - Token Setup Instructions</b></summary>
 
 1. **Enable [Google People API](https://console.cloud.google.com/marketplace/product/google/people.googleapis.com)**
 2. **Get your tokens**
@@ -57,7 +57,7 @@ cp backend/.env.example backend/.env
 </details>
 
 <details>
-<summary><b><img src="frontend/public/images/github-logo.png" width="16" height="16" alt="GitHub"> Instructions to get token for GitHub Auth</b></summary>
+<summary><b><img src="frontend/public/images/github-logo.png" width="16" height="16" alt="GitHub"> GitHub Auth - Token Setup Instructions</b></summary>
 
 1. **Visit [https://github.com/settings/developers](https://github.com/settings/developers)**
 	*  Click **OAuth Apps** → **New OAuth App**

--- a/backend/app/agents/tools/pattern_analyzer.py
+++ b/backend/app/agents/tools/pattern_analyzer.py
@@ -123,8 +123,8 @@ class PatternAnalyzerTool(BaseTool):
         hour_counts = Counter(event['hour'] for event in events)
         weekend_count = sum(1 for event in events if event['is_weekend'])
         
-        # After-hours work (6 PM to 8 AM)
-        after_hours_count = sum(1 for event in events if event['hour'] >= 18 or event['hour'] <= 8)
+        # After-hours work (before 9 AM or after 5 PM)
+        after_hours_count = sum(1 for event in events if event['hour'] < 9 or event['hour'] >= 17)
         after_hours_rate = after_hours_count / len(events) if events else 0
         
         if after_hours_rate > 0.3:
@@ -247,8 +247,8 @@ class PatternAnalyzerTool(BaseTool):
         hour_counts = Counter(event['hour'] for event in events)
         weekend_count = sum(1 for event in events if event['is_weekend'])
         
-        # After-hours messaging
-        after_hours_count = sum(1 for event in events if event['hour'] >= 18 or event['hour'] <= 8)
+        # After-hours messaging (before 9 AM or after 5 PM)
+        after_hours_count = sum(1 for event in events if event['hour'] < 9 or event['hour'] >= 17)
         after_hours_rate = after_hours_count / len(events) if events else 0
         
         if after_hours_rate > 0.25:

--- a/backend/app/agents/tools/workload_analyzer.py
+++ b/backend/app/agents/tools/workload_analyzer.py
@@ -157,9 +157,9 @@ class WorkloadAnalyzerTool(BaseTool):
         return metrics
     
     def _count_after_hours_activities(self, user_data: Dict[str, Any]) -> int:
-        """Count activities outside normal business hours (6 PM - 8 AM)."""
+        """Count activities outside normal business hours (9 AM - 5 PM)."""
         count = 0
-        
+
         for data_type in ['incidents', 'commits', 'messages']:
             for item in user_data.get(data_type, []):
                 if 'timestamp' in item or 'created_at' in item:
@@ -169,13 +169,13 @@ class WorkloadAnalyzerTool(BaseTool):
                             dt = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
                         else:
                             dt = datetime.fromtimestamp(timestamp)
-                        
-                        # After hours: before 8 AM or after 6 PM
-                        if dt.hour < 8 or dt.hour >= 18:
+
+                        # After hours: before 9 AM or after 5 PM
+                        if dt.hour < 9 or dt.hour >= 17:
                             count += 1
                     except (ValueError, TypeError):
                         continue
-        
+
         return count
     
     def _count_weekend_activities(self, user_data: Dict[str, Any]) -> int:


### PR DESCRIPTION
## Summary
- Standardize after-hours calculation across the codebase to use 9 AM - 5 PM business hours
- Previously `workload_analyzer.py` and `pattern_analyzer.py` used 6 PM - 8 AM, while `data_collector.py` used 9 AM - 5 PM
- All analyzers now consistently define after-hours as before 9 AM or at/after 5 PM

## Files changed
- `backend/app/agents/tools/workload_analyzer.py` - `_count_after_hours_activities()`
- `backend/app/agents/tools/pattern_analyzer.py` - incident and messaging pattern analysis

## Test plan
- [ ] Verify after-hours calculations are consistent across all reports
- [ ] Check that incident and messaging after-hours rates reflect 9-5 business hours

🤖 Generated with [Claude Code](https://claude.ai/code)