### PR TITLE
Remove Slack icon from member cards

### DIFF
--- a/frontend/src/components/dashboard/TeamMembersList.tsx
+++ b/frontend/src/components/dashboard/TeamMembersList.tsx
@@ -157,23 +157,6 @@ export function TeamMembersList({
             </div>
           )}
 
-          {/* Slack - show if user has Slack mapping */}
-          {member.slack_user_id && (
-            <div className="flex items-center justify-center w-6 h-6 bg-white rounded-full border border-neutral-200" title="Slack">
-              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none">
-                {/* Official Slack logo pattern */}
-                <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52z" fill="#E01E5A"/>
-                <path d="M6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313z" fill="#E01E5A"/>
-                <path d="M8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834z" fill="#36C5F0"/>
-                <path d="M8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312z" fill="#36C5F0"/>
-                <path d="M18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834z" fill="#2EB67D"/>
-                <path d="M17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312z" fill="#2EB67D"/>
-                <path d="M15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52z" fill="#ECB22E"/>
-                <path d="M15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" fill="#ECB22E"/>
-              </svg>
-            </div>
-          )}
-
           {/* Jira - show if user has Jira mapping */}
           {isJiraEnabled && member.jira_account_id && (
             <div className="flex items-center justify-center w-6 h-6 bg-blue-50 rounded-full border border-blue-200" title="Jira">


### PR DESCRIPTION
Removes the Slack integration icon from team member cards since sentiment analysis has been disabled.

## Changes
- Removed Slack icon from TeamMembersList.tsx member cards
- Member cards now only show: GitHub, Jira, Linear, and Survey icons

## Reason
Slack data collection has been disabled/commented out, so the icon no longer represents active data integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)