### PR TITLE
Fix: Critical bugs in timezone feature (e04ffa4)

### DIFF
--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -1113,7 +1113,7 @@ class UnifiedBurnoutAnalyzer:
                 if self.platform == "pagerduty":
                     api_users = await self.client.get_users(limit=10000)
                 else:  # rootly
-                    api_users, _ = await self.client.get_users(limit=10000)
+                    api_users = await self.client.get_users(limit=10000)
 
                 # Store API users for timezone map (will be used by _build_user_tz_map)
                 self._api_users_for_timezone = api_users

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -1336,8 +1336,8 @@ class UnifiedBurnoutAnalyzer:
 
             # Extract timezone from API response format
             if self.platform == "pagerduty":
-                # PagerDuty: flat format {"time_zone": "America/New_York"}
-                tz = user.get("time_zone")
+                # PagerDuty: flat format {"timezone": "America/New_York"}
+                tz = user.get("timezone")
             else:
                 # Rootly: JSONAPI format {"attributes": {"time_zone": "America/New_York"}}
                 attrs = user.get("attributes") or {}


### PR DESCRIPTION
## Problem
Commit e04ffa4 (Add user timezone support and configurable working hours) introduced two critical bugs that broke all analyses:

### Bug 1: Incorrect tuple unpacking for Rootly API
**Error:** `too many values to unpack (expected 2)`

**Root cause:** Line 1116 assumed `get_users()` always returns a tuple:
```python
api_users, _ = await self.client.get_users(limit=10000)
```

But `get_users()` only returns `(users, included)` when called with `include_role=True`. Without that parameter, it returns just a list.

**Fix:** Remove tuple unpacking:
```python
api_users = await self.client.get_users(limit=10000)
```

### Bug 2: Wrong PagerDuty timezone field name  
**Root cause:** Line 1340 changed from `timezone` to `time_zone`:
```python
tz = user.get("time_zone")  # WRONG
```

But PagerDuty API uses `"timezone"` not `"time_zone"`, causing all timezone lookups to return None.

**Fix:** Revert to correct field name:
```python
tz = user.get("timezone")  # CORRECT
```

## Testing
- Verified Rootly analysis completes without "too many values to unpack" error
- Confirmed PagerDuty timezone lookups work correctly
- Both fixes tested on staging

## Impact
These bugs caused 100% analysis failure rate for commit e04ffa4, returning 0 members and 0 incidents.