### PR TITLE
Clarify Health Check-ins trend shows wellbeing status

### DIFF
--- a/frontend/src/components/dashboard/SurveyResultsCard.tsx
+++ b/frontend/src/components/dashboard/SurveyResultsCard.tsx
@@ -120,7 +120,7 @@ export function SurveyResultsCard({ surveyData }: SurveyResultsCardProps): React
           {surveyData.trend && (
             <div className="flex items-center gap-2">
               {getTrendIcon(surveyData.trend)}
-              <span className="text-xs text-neutral-500 capitalize">{surveyData.trend}</span>
+              <span className="text-xs text-neutral-500 capitalize">Wellbeing {surveyData.trend}</span>
             </div>
           )}
         </div>

--- a/frontend/src/components/dashboard/SurveyResultsCard.tsx
+++ b/frontend/src/components/dashboard/SurveyResultsCard.tsx
@@ -120,7 +120,7 @@ export function SurveyResultsCard({ surveyData }: SurveyResultsCardProps): React
           {surveyData.trend && (
             <div className="flex items-center gap-2">
               {getTrendIcon(surveyData.trend)}
-              <span className="text-xs text-neutral-500 capitalize">{surveyData.trend}</span>
+              <span className="text-xs text-neutral-500 capitalize">Feeling {surveyData.trend}</span>
             </div>
           )}
         </div>

--- a/frontend/src/components/dashboard/SurveyResultsCard.tsx
+++ b/frontend/src/components/dashboard/SurveyResultsCard.tsx
@@ -120,7 +120,7 @@ export function SurveyResultsCard({ surveyData }: SurveyResultsCardProps): React
           {surveyData.trend && (
             <div className="flex items-center gap-2">
               {getTrendIcon(surveyData.trend)}
-              <span className="text-xs text-neutral-500 capitalize">Feeling {surveyData.trend}</span>
+              <span className="text-xs text-neutral-500 capitalize">{surveyData.trend}</span>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Added "Wellbeing" prefix to the Health Check-ins trend indicator to clarify that the trend represents overall wellbeing (combined feeling + workload scores), not just a single metric

## Changes
- Updated SurveyResultsCard to show "Wellbeing improving/declining/stable" instead of just "improving/declining/stable"

## Context
The trend is calculated from combined scores (average of feeling_score + workload_score), so labeling it as "Wellbeing" makes it clearer to users what aspect is trending.

## Test plan
- [ ] View dashboard with survey data
- [ ] Verify trend indicator now shows "Wellbeing improving" (or declining/stable)
- [ ] Confirm the clarification makes the metric clearer to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)