### PR TITLE
Fix migration runner false-positive bug that caused silent schema failures

### DIFF
--- a/backend/migrations/2026_01_23_repair_survey_periods_migration.sql
+++ b/backend/migrations/2026_01_23_repair_survey_periods_migration.sql
@@ -1,0 +1,113 @@
+-- Migration: Repair false-positive migration 040_add_survey_periods
+-- Description: This migration detects and repairs a scenario where migration 040 was
+--              marked as complete without actually running (due to a bug in the migration
+--              runner that marked migrations complete even when SQL files failed to load).
+--
+-- Background: The migration runner had a bug where if load_sql_file() returned an empty
+--             list (due to FileNotFoundError or other issues), the migration would still
+--             be marked as "completed" because the for loop didn't execute but
+--             mark_migration_applied() still ran. This caused silent failures where
+--             migrations appeared to succeed but no schema changes were applied.
+--
+-- This migration is idempotent - it checks if columns/tables exist before creating them.
+
+-- ============================================================================
+-- Step 1: Remove false migration record if columns don't exist
+-- ============================================================================
+DO $$
+BEGIN
+    -- Check if migration 040 is marked as complete but columns don't exist
+    IF EXISTS (SELECT 1 FROM migrations WHERE name = '040_add_survey_periods' AND status = 'completed')
+       AND NOT EXISTS (
+           SELECT 1 FROM information_schema.columns
+           WHERE table_name = 'survey_schedules'
+           AND column_name = 'follow_up_reminders_enabled'
+       ) THEN
+        -- Remove the false migration record so it will be properly re-run
+        DELETE FROM migrations WHERE name = '040_add_survey_periods';
+        RAISE NOTICE 'Removed false-positive migration record for 040_add_survey_periods';
+    END IF;
+END $$;
+
+-- ============================================================================
+-- Step 2: Re-apply the schema changes (idempotent - uses IF NOT EXISTS)
+-- ============================================================================
+
+-- Add new columns to survey_schedules
+ALTER TABLE survey_schedules
+ADD COLUMN IF NOT EXISTS follow_up_reminders_enabled BOOLEAN DEFAULT TRUE;
+
+ALTER TABLE survey_schedules
+ADD COLUMN IF NOT EXISTS follow_up_message_template VARCHAR(500);
+
+-- Create survey_periods table
+CREATE TABLE IF NOT EXISTS survey_periods (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id),
+    user_correlation_id INTEGER NOT NULL REFERENCES user_correlations(id),
+    user_id INTEGER REFERENCES users(id),
+    email VARCHAR(255) NOT NULL,
+
+    -- Period configuration
+    frequency_type VARCHAR(20) NOT NULL,  -- 'daily', 'weekday', 'weekly'
+    period_start_date DATE NOT NULL,
+    period_end_date DATE NOT NULL,
+
+    -- Status tracking
+    status VARCHAR(20) DEFAULT 'pending' NOT NULL,  -- 'pending', 'completed', 'expired'
+    initial_sent_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    last_reminder_sent_at TIMESTAMP WITH TIME ZONE,
+    reminder_count INTEGER DEFAULT 0,
+
+    -- Response linking
+    response_id INTEGER REFERENCES user_burnout_reports(id),
+    completed_at TIMESTAMP WITH TIME ZONE,
+    expired_at TIMESTAMP WITH TIME ZONE,
+
+    -- Timestamps
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes for survey_periods
+CREATE INDEX IF NOT EXISTS idx_survey_periods_org_status
+ON survey_periods(organization_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_survey_periods_email_status
+ON survey_periods(email, status);
+
+CREATE INDEX IF NOT EXISTS idx_survey_periods_period_dates
+ON survey_periods(period_start_date, period_end_date);
+
+CREATE INDEX IF NOT EXISTS idx_survey_periods_user_correlation
+ON survey_periods(user_correlation_id, status);
+
+-- Unique constraint for pending periods
+CREATE UNIQUE INDEX IF NOT EXISTS uq_survey_periods_pending_user_org
+ON survey_periods(organization_id, user_correlation_id)
+WHERE status = 'pending';
+
+-- Add CHECK constraints (idempotent)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'check_survey_period_status'
+    ) THEN
+        ALTER TABLE survey_periods
+        ADD CONSTRAINT check_survey_period_status
+        CHECK (status IN ('pending', 'completed', 'expired'));
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'check_survey_period_frequency_type'
+    ) THEN
+        ALTER TABLE survey_periods
+        ADD CONSTRAINT check_survey_period_frequency_type
+        CHECK (frequency_type IN ('daily', 'weekday', 'weekly'));
+    END IF;
+END $$;

--- a/backend/migrations/migration_runner.py
+++ b/backend/migrations/migration_runner.py
@@ -92,10 +92,25 @@ class MigrationRunner:
             logger.error(f"❌ Failed to mark migration as applied: {e}")
 
     def run_sql_migration(self, migration_name: str, sql_commands: List[str]) -> bool:
-        """Run a SQL-based migration"""
+        """Run a SQL-based migration.
+
+        IMPORTANT: This function includes a critical check for empty sql_commands.
+        Previously, if load_sql_file() returned [] (due to FileNotFoundError or other
+        issues), the for loop wouldn't execute but mark_migration_applied() would still
+        run, causing "phantom" migrations that appeared complete but applied no changes.
+        This caused recurring production issues where schema changes were missing.
+        See migration 041_repair_survey_periods_migration for an example fix.
+        """
         if self.is_migration_applied(migration_name):
             logger.info(f"⏭️  Skipping already applied migration: {migration_name}")
             return True
+
+        # CRITICAL: Don't mark migration as complete if no SQL commands to run
+        # This prevents silent failures when SQL files are missing or fail to load
+        # (fixes a bug that caused 040_add_survey_periods to be marked complete without running)
+        if not sql_commands:
+            logger.error(f"❌ Migration {migration_name} has no SQL commands - skipping to prevent false completion")
+            return False
 
         logger.info(f"🔧 Running migration: {migration_name}")
 
@@ -1149,6 +1164,11 @@ class MigrationRunner:
                 "name": "040_add_survey_periods",
                 "description": "Add survey_periods table for daily follow-up reminders tracking",
                 "sql_file": "2026_01_22_add_survey_periods.sql"
+            },
+            {
+                "name": "041_repair_survey_periods_migration",
+                "description": "Repair false-positive migration 040 if columns don't exist (fixes migration runner bug)",
+                "sql_file": "2026_01_23_repair_survey_periods_migration.sql"
             },
             # Add future migrations here with incrementing numbers
         ]


### PR DESCRIPTION
## Summary

- Fixes critical bug in migration runner that marked migrations as "complete" even when SQL files failed to load
- Adds repair migration to fix the falsely-completed migration 040_add_survey_periods
- Resolves Slack integration error: `column survey_schedules.follow_up_reminders_enabled does not exist`

## Root Cause

The migration runner had a bug where `run_sql_migration()` would mark migrations as complete even with empty SQL commands:

```python
# The bug:
for sql in sql_commands:    # If sql_commands is [], this never executes
    self.db.execute(text(sql))

self.db.commit()
self.mark_migration_applied(migration_name)  # STILL RUNS!
```

When `load_sql_file()` fails (FileNotFoundError, Docker cache issues, etc.), it returns `[]`, causing "phantom" migrations that appear complete but apply no schema changes.

## Evidence This Was Recurring

Found multiple past commits fixing migration-related issues:
- `a955184` Fix logging errors and migration failure
- `371923c` fixed migration bug  
- `f6b73d7` db migrations issue resolved
- `ccbe0b8` Fix migration 024 to be idempotent for constraints

## Changes

1. **Bug fix**: Added empty check in `run_sql_migration()` to fail if no SQL commands
2. **Repair migration**: `041_repair_survey_periods_migration` detects and fixes false-positive migration 040
3. **Documentation**: Added comments explaining the bug pattern for future maintainers

## Test plan

- [ ] Verify migration runner logs error for empty SQL commands
- [ ] Deploy to staging and verify `follow_up_reminders_enabled` column exists
- [ ] Verify Slack integration page loads without errors