### PR TITLE
Fix ModuleNotFoundError in warm cache background task

### DIFF
--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -146,7 +146,7 @@ class WarmCacheResponse(BaseModel):
 
 async def _warm_cache_background_task(user_id: int) -> None:
     """Background task to warm all integration permission caches."""
-    from ...database import SessionLocal
+    from ...models import SessionLocal
     from ...services.integration_validator import IntegrationValidator
 
     try:


### PR DESCRIPTION
## Summary
- Fixed incorrect import path in `_warm_cache_background_task` function
- Changed `from ...database import SessionLocal` to `from ...models import SessionLocal`
- The `app.database` module doesn't exist; `SessionLocal` is exported from `app.models`

## Test plan
- [ ] Deploy to staging and verify login flow completes without errors
- [ ] Check logs for successful `[WARM_CACHE]` completion messages