### PR TITLE
Add startup cleanup for stuck analyses

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ FastAPI main application for On-call Burnout Detector.
 """
 import os
 import logging
+from datetime import datetime, timedelta
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
@@ -181,6 +182,47 @@ async def startup_event():
         print("✅ Loaded survey schedules from database")
     except Exception as e:
         print(f"⚠️ Error loading survey schedules: {str(e)}")
+    finally:
+        db.close()
+
+    # Clean up stuck analyses (analyses that have been "running" for too long)
+    await cleanup_stuck_analyses()
+
+
+async def cleanup_stuck_analyses():
+    """
+    Mark analyses that have been stuck in 'running' status for too long as failed.
+    This handles cases where the server crashed/restarted while an analysis was running.
+    """
+    from app.models import SessionLocal, Analysis
+
+    # Analyses running for more than 30 minutes are considered stuck
+    stuck_threshold = timedelta(minutes=30)
+    cutoff_time = datetime.utcnow() - stuck_threshold
+
+    db = SessionLocal()
+    try:
+        # Find all analyses that have been running for too long
+        stuck_analyses = db.query(Analysis).filter(
+            Analysis.status == "running",
+            Analysis.created_at < cutoff_time
+        ).all()
+
+        if stuck_analyses:
+            print(f"🔧 Found {len(stuck_analyses)} stuck analyses to clean up")
+            for analysis in stuck_analyses:
+                analysis.status = "failed"
+                analysis.error_message = "Analysis was interrupted (server restart). Please run a new analysis."
+                analysis.completed_at = datetime.utcnow()
+                print(f"  - Marked analysis {analysis.id} as failed (was running since {analysis.created_at})")
+
+            db.commit()
+            print(f"✅ Cleaned up {len(stuck_analyses)} stuck analyses")
+        else:
+            print("✅ No stuck analyses found")
+    except Exception as e:
+        print(f"⚠️ Error cleaning up stuck analyses: {str(e)}")
+        db.rollback()
     finally:
         db.close()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ FastAPI main application for On-call Burnout Detector.
 """
 import os
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
@@ -198,7 +198,7 @@ async def cleanup_stuck_analyses():
 
     # Analyses running for more than 30 minutes are considered stuck
     stuck_threshold = timedelta(minutes=30)
-    cutoff_time = datetime.utcnow() - stuck_threshold
+    cutoff_time = datetime.now(timezone.utc) - stuck_threshold
 
     db = SessionLocal()
     try:
@@ -210,19 +210,30 @@ async def cleanup_stuck_analyses():
 
         if stuck_analyses:
             print(f"🔧 Found {len(stuck_analyses)} stuck analyses to clean up")
+            cleaned_count = 0
             for analysis in stuck_analyses:
-                analysis.status = "failed"
-                analysis.error_message = "Analysis was interrupted (server restart). Please run a new analysis."
-                analysis.completed_at = datetime.utcnow()
-                print(f"  - Marked analysis {analysis.id} as failed (was running since {analysis.created_at})")
+                try:
+                    # Re-check status to avoid race conditions
+                    db.refresh(analysis)
+                    if analysis.status != "running":
+                        print(f"  - Skipping analysis {analysis.id} (status changed to {analysis.status})")
+                        continue
 
-            db.commit()
-            print(f"✅ Cleaned up {len(stuck_analyses)} stuck analyses")
+                    analysis.status = "failed"
+                    analysis.error_message = "Analysis was interrupted (server restart). Please run a new analysis."
+                    analysis.completed_at = datetime.now(timezone.utc)
+                    db.commit()
+                    cleaned_count += 1
+                    print(f"  - Marked analysis {analysis.id} as failed (was running since {analysis.created_at})")
+                except Exception as e:
+                    print(f"  - Failed to clean up analysis {analysis.id}: {str(e)}")
+                    db.rollback()
+
+            print(f"✅ Cleaned up {cleaned_count} stuck analyses")
         else:
             print("✅ No stuck analyses found")
     except Exception as e:
         print(f"⚠️ Error cleaning up stuck analyses: {str(e)}")
-        db.rollback()
     finally:
         db.close()
 


### PR DESCRIPTION
## Summary
- Add `cleanup_stuck_analyses()` function that runs on server startup
- Marks analyses stuck in 'running' status for >30 minutes as 'failed'
- Prevents infinite frontend polling for analyses that will never complete

## Problem
Analyses can get stuck in 'running' status if:
- Server crashes during analysis
- Server restarts while analysis is in progress
- Background task fails silently

This causes the frontend to poll `/analyses/{id}` indefinitely.

## Test plan
- [ ] Deploy and verify stuck analyses are cleaned up on startup
- [ ] Check logs for cleanup messages
- [ ] Verify frontend stops polling after cleanup