### PR TITLE
Fix 401 errors: Only render NotificationDrawer when authenticated

### DIFF
--- a/frontend/src/components/TopPanel.tsx
+++ b/frontend/src/components/TopPanel.tsx
@@ -39,15 +39,22 @@ export function TopPanel() {
     const userName = localStorage.getItem("user_name")
     const userEmail = localStorage.getItem("user_email")
     const userRole = localStorage.getItem("user_role")
-    // Only set userInfo if auth_token exists along with user details
+    // Require auth_token to exist along with user details.
+    // Note: True token validation (signature, expiration) happens on the backend.
+    // This check prevents unnecessary UI rendering when there's clearly no session.
+    // Invalid tokens will result in 401 errors that redirect to login.
     if (authToken && userName && userEmail) {
       setUserInfo({ name: userName, email: userEmail, role: userRole || undefined })
     }
   }, [])
 
   const handleSignOut = () => {
-    // Clear auth token and redirect
+    // Clear all auth-related data and redirect
     localStorage.removeItem("auth_token")
+    localStorage.removeItem("user_name")
+    localStorage.removeItem("user_email")
+    localStorage.removeItem("user_role")
+    setUserInfo(null)
     router.push("/")
   }
 

--- a/frontend/src/components/TopPanel.tsx
+++ b/frontend/src/components/TopPanel.tsx
@@ -107,10 +107,11 @@ export function TopPanel() {
             </nav>
           </div>
 
-          {/* Right: notifications + user */}
+          {/* Right: notifications + user (only shown when authenticated) */}
           <div className="flex items-center gap-3">
-            <NotificationDrawer />
             {userInfo && (
+              <>
+                <NotificationDrawer />
               <DropdownMenu open={isDropdownOpen} onOpenChange={(open) => {
                 setIsDropdownOpen(open)
                 // Close dropdown when dialog opens
@@ -195,6 +196,7 @@ export function TopPanel() {
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
+              </>
             )}
           </div>
         </div>

--- a/frontend/src/components/TopPanel.tsx
+++ b/frontend/src/components/TopPanel.tsx
@@ -35,10 +35,14 @@ export function TopPanel() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
 
   useEffect(() => {
+    const authToken = localStorage.getItem("auth_token")
     const userName = localStorage.getItem("user_name")
     const userEmail = localStorage.getItem("user_email")
     const userRole = localStorage.getItem("user_role")
-    if (userName && userEmail) setUserInfo({ name: userName, email: userEmail, role: userRole || undefined })
+    // Only set userInfo if auth_token exists along with user details
+    if (authToken && userName && userEmail) {
+      setUserInfo({ name: userName, email: userEmail, role: userRole || undefined })
+    }
   }, [])
 
   const handleSignOut = () => {


### PR DESCRIPTION
## Summary
- Fixed 401 Unauthorized errors on `/api/notifications` endpoint by conditionally rendering `NotificationDrawer` only when user is authenticated
- Previously, the notification drawer was rendered unconditionally, causing the `useNotifications` hook to poll for notifications even when no user was logged in
- This resulted in requests with `Authorization: Bearer null` headers causing 401 errors

## Changes
- Moved `NotificationDrawer` component inside the `{userInfo && (...)}` conditional block in `TopPanel.tsx`
- Notifications now only poll when a user is authenticated

## Test plan
- [ ] Verify no 401 errors in server logs when visiting the app while not logged in
- [ ] Verify notifications still work correctly when logged in
- [ ] Verify notification polling stops after logout