### PR TITLE
Add survey schedule audit tracking

### DIFF
--- a/.beads/sync-state.json
+++ b/.beads/sync-state.json
@@ -1,7 +1,0 @@
-{
-  "last_failure": "2026-01-26T09:44:33.123431-08:00",
-  "failure_count": 1,
-  "backoff_until": "2026-01-26T09:45:03.123432-08:00",
-  "needs_manual_sync": false,
-  "failure_reason": "git pull failed: exit status 1\nfatal: couldn't find remote ref fix-slack-survey-synced-members\n"
-}

--- a/.beads/sync-state.json
+++ b/.beads/sync-state.json
@@ -1,0 +1,7 @@
+{
+  "last_failure": "2026-01-26T09:44:33.123431-08:00",
+  "failure_count": 1,
+  "backoff_until": "2026-01-26T09:45:03.123432-08:00",
+  "needs_manual_sync": false,
+  "failure_reason": "git pull failed: exit status 1\nfatal: couldn't find remote ref fix-slack-survey-synced-members\n"
+}

--- a/backend/app/api/endpoints/surveys.py
+++ b/backend/app/api/endpoints/surveys.py
@@ -103,6 +103,9 @@ class SurveyScheduleResponse(BaseModel):
     reminder_message_template: str
     follow_up_reminders_enabled: bool
     follow_up_message_template: Optional[str]
+    last_modified_by_user_id: Optional[int]
+    last_modified_by_name: Optional[str]
+    last_modified_at: Optional[str]
 
 
 class UserPreferenceUpdate(BaseModel):
@@ -182,10 +185,13 @@ async def create_or_update_survey_schedule(
         if schedule_data.follow_up_message_template:
             existing_schedule.follow_up_message_template = schedule_data.follow_up_message_template
 
+        # Track who made this change
+        existing_schedule.last_modified_by_user_id = current_user.id
+
         db.commit()
         db.refresh(existing_schedule)
         schedule = existing_schedule
-        logger.info(f"Updated survey schedule for org {organization_id}")
+        logger.info(f"Updated survey schedule for org {organization_id} by user {current_user.id}")
     else:
         # Create new
         schedule = SurveySchedule(
@@ -199,7 +205,8 @@ async def create_or_update_survey_schedule(
             send_reminder=schedule_data.send_reminder,
             reminder_time=reminder_time,
             reminder_hours_after=schedule_data.reminder_hours_after,
-            follow_up_reminders_enabled=schedule_data.follow_up_reminders_enabled
+            follow_up_reminders_enabled=schedule_data.follow_up_reminders_enabled,
+            last_modified_by_user_id=current_user.id
         )
 
         if schedule_data.message_template:
@@ -212,7 +219,7 @@ async def create_or_update_survey_schedule(
         db.add(schedule)
         db.commit()
         db.refresh(schedule)
-        logger.info(f"Created survey schedule for org {organization_id}")
+        logger.info(f"Created survey schedule for org {organization_id} by user {current_user.id}")
 
     # Reload scheduler with new schedule
     if SCHEDULER_AVAILABLE and survey_scheduler:
@@ -221,6 +228,11 @@ async def create_or_update_survey_schedule(
         except Exception as e:
             logger.error(f"Failed to reload scheduler: {e}")
             # Continue anyway - schedule is saved in DB
+
+    # Get last modified by user info
+    last_modified_by_name = None
+    if schedule.last_modified_by_user_id and schedule.last_modified_by:
+        last_modified_by_name = schedule.last_modified_by.name
 
     return {
         "id": schedule.id,
@@ -238,6 +250,9 @@ async def create_or_update_survey_schedule(
         "reminder_message_template": schedule.reminder_message_template,
         "follow_up_reminders_enabled": schedule.follow_up_reminders_enabled,
         "follow_up_message_template": schedule.follow_up_message_template,
+        "last_modified_by_user_id": schedule.last_modified_by_user_id,
+        "last_modified_by_name": last_modified_by_name,
+        "last_modified_at": schedule.last_modified_at.isoformat() if schedule.last_modified_at else None,
         "message": "Survey schedule configured successfully"
     }
 
@@ -266,11 +281,19 @@ async def get_survey_schedule(
             "reminder_hours_after": 5,
             "follow_up_reminders_enabled": True,
             "follow_up_message_template": None,
+            "last_modified_by_user_id": None,
+            "last_modified_by_name": None,
+            "last_modified_at": None,
             "message": "No survey schedule configured"
         }
 
     # Derive frequency_type with fallback for legacy data
     effective_frequency = schedule.frequency_type or ('weekday' if schedule.send_weekdays_only else 'daily')
+
+    # Get last modified by user info
+    last_modified_by_name = None
+    if schedule.last_modified_by_user_id and schedule.last_modified_by:
+        last_modified_by_name = schedule.last_modified_by.name
 
     return {
         "id": schedule.id,
@@ -287,7 +310,10 @@ async def get_survey_schedule(
         "message_template": schedule.message_template,
         "reminder_message_template": schedule.reminder_message_template,
         "follow_up_reminders_enabled": schedule.follow_up_reminders_enabled if schedule.follow_up_reminders_enabled is not None else True,
-        "follow_up_message_template": schedule.follow_up_message_template
+        "follow_up_message_template": schedule.follow_up_message_template,
+        "last_modified_by_user_id": schedule.last_modified_by_user_id,
+        "last_modified_by_name": last_modified_by_name,
+        "last_modified_at": schedule.last_modified_at.isoformat() if schedule.last_modified_at else None
     }
 
 

--- a/backend/app/api/endpoints/surveys.py
+++ b/backend/app/api/endpoints/surveys.py
@@ -5,7 +5,7 @@ import logging
 from datetime import time, datetime, timedelta
 from typing import Optional, List
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from pydantic import BaseModel
 
 from ...models import get_db, User
@@ -160,7 +160,9 @@ async def create_or_update_survey_schedule(
         raise HTTPException(status_code=400, detail="Invalid time format. Use HH:MM (e.g., 09:00)")
 
     # Check if schedule exists (order by id desc for deterministic results)
-    existing_schedule = db.query(SurveySchedule).filter(
+    existing_schedule = db.query(SurveySchedule).options(
+        joinedload(SurveySchedule.last_modified_by)
+    ).filter(
         SurveySchedule.organization_id == organization_id
     ).order_by(SurveySchedule.id.desc()).first()
 
@@ -263,7 +265,9 @@ async def get_survey_schedule(
     db: Session = Depends(get_db)
 ):
     """Get current survey schedule for user's organization."""
-    schedule = db.query(SurveySchedule).filter(
+    schedule = db.query(SurveySchedule).options(
+        joinedload(SurveySchedule.last_modified_by)
+    ).filter(
         SurveySchedule.organization_id == current_user.organization_id
     ).first()
 

--- a/backend/app/api/endpoints/surveys.py
+++ b/backend/app/api/endpoints/surveys.py
@@ -233,8 +233,12 @@ async def create_or_update_survey_schedule(
 
     # Get last modified by user info
     last_modified_by_name = None
-    if schedule.last_modified_by_user_id and schedule.last_modified_by:
-        last_modified_by_name = schedule.last_modified_by.name
+    if schedule.last_modified_by_user_id:
+        try:
+            if schedule.last_modified_by and hasattr(schedule.last_modified_by, 'name'):
+                last_modified_by_name = schedule.last_modified_by.name
+        except Exception as e:
+            logger.warning(f"Failed to load last_modified_by user for schedule {schedule.id}: {e}")
 
     return {
         "id": schedule.id,
@@ -296,8 +300,12 @@ async def get_survey_schedule(
 
     # Get last modified by user info
     last_modified_by_name = None
-    if schedule.last_modified_by_user_id and schedule.last_modified_by:
-        last_modified_by_name = schedule.last_modified_by.name
+    if schedule.last_modified_by_user_id:
+        try:
+            if schedule.last_modified_by and hasattr(schedule.last_modified_by, 'name'):
+                last_modified_by_name = schedule.last_modified_by.name
+        except Exception as e:
+            logger.warning(f"Failed to load last_modified_by user for schedule {schedule.id}: {e}")
 
     return {
         "id": schedule.id,

--- a/backend/app/models/survey_schedule.py
+++ b/backend/app/models/survey_schedule.py
@@ -1,7 +1,8 @@
 """
 Survey schedule configuration for automated daily burnout check-ins.
 """
-from sqlalchemy import Column, Integer, String, Boolean, Time, ForeignKey
+from sqlalchemy import Column, Integer, String, Boolean, Time, ForeignKey, DateTime
+from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 from .base import Base
 
@@ -49,8 +50,13 @@ class SurveySchedule(Base):
         "You just need to answer it once this {period_name}, or I'll remind you again tomorrow."
     ))
 
+    # Audit tracking
+    last_modified_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    last_modified_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
     # Relationships
     organization = relationship("Organization", backref="survey_schedule")
+    last_modified_by = relationship("User", foreign_keys=[last_modified_by_user_id])
 
 
 class UserSurveyPreference(Base):

--- a/backend/migrations/2026_01_26_add_last_modified_to_survey_schedules.sql
+++ b/backend/migrations/2026_01_26_add_last_modified_to_survey_schedules.sql
@@ -1,0 +1,25 @@
+-- Migration: Add last_modified tracking to survey_schedules table
+-- Date: 2026-01-26
+-- Description: Adds last_modified_by_user_id and last_modified_at columns to track who last configured the automated survey schedule
+
+-- Add last_modified_by_user_id column (nullable, references users table)
+ALTER TABLE survey_schedules
+ADD COLUMN last_modified_by_user_id INTEGER;
+
+-- Add foreign key constraint
+ALTER TABLE survey_schedules
+ADD CONSTRAINT fk_survey_schedules_last_modified_by
+FOREIGN KEY (last_modified_by_user_id) REFERENCES users(id) ON DELETE SET NULL;
+
+-- Add last_modified_at column with default to current timestamp
+ALTER TABLE survey_schedules
+ADD COLUMN last_modified_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP;
+
+-- Create index on last_modified_by_user_id for faster lookups
+CREATE INDEX idx_survey_schedules_last_modified_by ON survey_schedules(last_modified_by_user_id);
+
+-- Backfill existing records: Set last_modified_at to current time
+-- Note: last_modified_by_user_id will remain NULL for existing records since we can't determine who created them
+UPDATE survey_schedules
+SET last_modified_at = CURRENT_TIMESTAMP
+WHERE last_modified_at IS NULL;

--- a/backend/migrations/2026_01_26_add_last_modified_to_survey_schedules.sql
+++ b/backend/migrations/2026_01_26_add_last_modified_to_survey_schedules.sql
@@ -15,8 +15,9 @@ FOREIGN KEY (last_modified_by_user_id) REFERENCES users(id) ON DELETE SET NULL;
 ALTER TABLE survey_schedules
 ADD COLUMN last_modified_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP;
 
--- Create index on last_modified_by_user_id for faster lookups
+-- Create indexes for faster lookups
 CREATE INDEX idx_survey_schedules_last_modified_by ON survey_schedules(last_modified_by_user_id);
+CREATE INDEX idx_survey_schedules_last_modified_at ON survey_schedules(last_modified_at);
 
 -- Backfill existing records: Set last_modified_at to current time
 -- Note: last_modified_by_user_id will remain NULL for existing records since we can't determine who created them

--- a/backend/migrations/migration_runner.py
+++ b/backend/migrations/migration_runner.py
@@ -1216,6 +1216,11 @@ class MigrationRunner:
                 "description": "Repair false-positive migration 040 if columns don't exist (fixes migration runner bug)",
                 "sql_file": "2026_01_23_repair_survey_periods_migration.sql"
             },
+            {
+                "name": "042_add_last_modified_to_survey_schedules",
+                "description": "Add last_modified_by_user_id and last_modified_at columns to track survey schedule changes",
+                "sql_file": "2026_01_26_add_last_modified_to_survey_schedules.sql"
+            },
             # Add future migrations here with incrementing numbers
         ]
 

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -74,6 +74,7 @@ export function SlackSurveyTabs({
   const [showSaveConfirmation, setShowSaveConfirmation] = useState(false)
   const [scheduleAccordionOpen, setScheduleAccordionOpen] = useState(false)
   const [lastModifiedByName, setLastModifiedByName] = useState<string | null>(null)
+  const [lastModifiedByUserId, setLastModifiedByUserId] = useState<number | null>(null)
   const [lastModifiedAt, setLastModifiedAt] = useState<string | null>(null)
 
   // Recipient selection state
@@ -177,6 +178,7 @@ export function SlackSurveyTabs({
 
           // Load last modified info
           setLastModifiedByName(data.last_modified_by_name || null)
+          setLastModifiedByUserId(data.last_modified_by_user_id || null)
           setLastModifiedAt(data.last_modified_at || null)
         } else {
           // Handle case where no schedule is configured (shouldn't happen with new backend)
@@ -588,9 +590,9 @@ export function SlackSurveyTabs({
                     {Math.max(0, selectedRecipients.size)} {selectedRecipients.size === 1 ? 'user' : 'users'} selected
                   </p>
                 )}
-                {lastModifiedByName && lastModifiedAt && (
+                {lastModifiedAt && lastModifiedByUserId && (
                   <p className="text-xs text-neutral-400 mt-1.5">
-                    Last updated by {lastModifiedByName} on {new Date(lastModifiedAt).toLocaleDateString()} at {new Date(lastModifiedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    Last schedule change: {lastModifiedByName || '[deleted user]'} on {new Date(lastModifiedAt).toLocaleDateString()} at {new Date(lastModifiedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   </p>
                 )}
               </div>

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -73,6 +73,8 @@ export function SlackSurveyTabs({
   const [savingSchedule, setSavingSchedule] = useState(false)
   const [showSaveConfirmation, setShowSaveConfirmation] = useState(false)
   const [scheduleAccordionOpen, setScheduleAccordionOpen] = useState(false)
+  const [lastModifiedByName, setLastModifiedByName] = useState<string | null>(null)
+  const [lastModifiedAt, setLastModifiedAt] = useState<string | null>(null)
 
   // Recipient selection state
   const [selectedRecipients, setSelectedRecipients] = useState<Set<number>>(new Set())
@@ -172,6 +174,10 @@ export function SlackSurveyTabs({
             setSavedDayOfWeek(data.day_of_week)
           }
           setFollowUpRemindersEnabled(data.follow_up_reminders_enabled !== false)
+
+          // Load last modified info
+          setLastModifiedByName(data.last_modified_by_name || null)
+          setLastModifiedAt(data.last_modified_at || null)
         } else {
           // Handle case where no schedule is configured (shouldn't happen with new backend)
           setScheduleEnabled(false)
@@ -580,6 +586,11 @@ export function SlackSurveyTabs({
                 {scheduleEnabled && (
                   <p className="text-xs font-medium text-purple-600 mt-1.5">
                     {Math.max(0, selectedRecipients.size)} {selectedRecipients.size === 1 ? 'user' : 'users'} selected
+                  </p>
+                )}
+                {lastModifiedByName && lastModifiedAt && (
+                  <p className="text-xs text-neutral-400 mt-1.5">
+                    Last updated by {lastModifiedByName} on {new Date(lastModifiedAt).toLocaleDateString()} at {new Date(lastModifiedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   </p>
                 )}
               </div>


### PR DESCRIPTION
Add tracking for who last modified the automated survey schedule and when.

## Changes
- Added `last_modified_by_user_id` and `last_modified_at` to SurveySchedule model
- Updated survey endpoints to capture current user on save/update  
- Display "Last schedule change: [name] on [date] at [time]" in UI
- Created database migration with proper constraints and eager loading

## Code Quality
- ✅ Null handling for deleted users
- ✅ Error handling with logging
- ✅ Eager loading to prevent N+1 queries
- ✅ Index on foreign key for performance