### PR TITLE
Security: Remove hardcoded defaults for JWT_SECRET_KEY and ENCRYPTION_KEY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: docker run --rm backend-test pip check
 
       - name: Test FastAPI app imports
-        run: docker run --rm -e DATABASE_URL=postgresql://test:test@localhost/test backend-test python -c "from app.main import app; print('FastAPI app loaded successfully')"
+        run: docker run --rm -e DATABASE_URL=postgresql://test:test@localhost/test -e JWT_SECRET_KEY=test-key-for-ci -e ENCRYPTION_KEY=test-encryption-key-for-ci backend-test python -c "from app.main import app; print('FastAPI app loaded successfully')"
 
   docker-compose:
     runs-on: ubuntu-latest

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,12 +7,16 @@
 DATABASE_URL=postgresql://postgres:password@postgres:5432/burnout_detector
 
 # JWT Secret - REQUIRED
+# Used to sign JWT authentication tokens
 # Generate with: openssl rand -hex 32
-JWT_SECRET_KEY=your-secret-key-change-in-production
+JWT_SECRET_KEY=
 
 # Token Encryption - REQUIRED
-# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-ENCRYPTION_KEY=your-fernet-encryption-key-here
+# Used to encrypt OAuth tokens stored in the database
+# For local development: Generate your own key with: openssl rand -base64 32
+# For production/staging: Use the environment-specific key (stored in Railway)
+# IMPORTANT: Changing this key will break all existing OAuth integrations in that environment
+ENCRYPTION_KEY=
 
 # ====================================
 # OPTIONAL - Only if using integrations

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,13 +18,22 @@ class Settings:
         )
     
     # JWT
-    JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY", "your-secret-key-change-in-production")
+    JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY")
+    if not JWT_SECRET_KEY:
+        raise ValueError(
+            "JWT_SECRET_KEY environment variable is required. "
+            "Generate with: openssl rand -hex 32"
+        )
     JWT_ALGORITHM: str = "HS256"
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 days
 
     # Token Encryption (separate from JWT signing for security)
-    # Falls back to old default for backward compatibility with tokens encrypted before PR #269
-    ENCRYPTION_KEY: str = os.getenv("ENCRYPTION_KEY", "your-secret-key-change-in-production")
+    ENCRYPTION_KEY: str = os.getenv("ENCRYPTION_KEY")
+    if not ENCRYPTION_KEY:
+        raise ValueError(
+            "ENCRYPTION_KEY environment variable is required. "
+            "Set this to encrypt OAuth tokens in the database."
+        )
 
     # Frontend URL for survey links
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,6 +8,10 @@ from dotenv import load_dotenv
 # Load environment variables from .env file
 load_dotenv()
 
+# Detect environment early for error message customization
+_ENV = os.getenv("ENVIRONMENT", "development")
+_IS_PRODUCTION = _ENV in ("production", "staging")
+
 class Settings:
     # Database
     DATABASE_URL: str = os.getenv("DATABASE_URL")
@@ -20,20 +24,26 @@ class Settings:
     # JWT
     JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY")
     if not JWT_SECRET_KEY:
-        raise ValueError(
-            "JWT_SECRET_KEY environment variable is required. "
-            "Generate with: openssl rand -hex 32"
-        )
+        if _IS_PRODUCTION:
+            raise ValueError("JWT_SECRET_KEY environment variable is required")
+        else:
+            raise ValueError(
+                "JWT_SECRET_KEY environment variable is required. "
+                "Generate with: openssl rand -hex 32"
+            )
     JWT_ALGORITHM: str = "HS256"
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 days
 
     # Token Encryption (separate from JWT signing for security)
     ENCRYPTION_KEY: str = os.getenv("ENCRYPTION_KEY")
     if not ENCRYPTION_KEY:
-        raise ValueError(
-            "ENCRYPTION_KEY environment variable is required. "
-            "Set this to encrypt OAuth tokens in the database."
-        )
+        if _IS_PRODUCTION:
+            raise ValueError("ENCRYPTION_KEY environment variable is required")
+        else:
+            raise ValueError(
+                "ENCRYPTION_KEY environment variable is required. "
+                "Generate with: openssl rand -base64 32"
+            )
 
     # Frontend URL for survey links
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")
@@ -62,7 +72,7 @@ class Settings:
     LINEAR_CLIENT_ID: Optional[str] = os.getenv("LINEAR_CLIENT_ID")
     LINEAR_CLIENT_SECRET: Optional[str] = os.getenv("LINEAR_CLIENT_SECRET")
 
-    # Environment detection
+    # Environment detection (must be set early for error message handling)
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")
 
     # Logging configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - DEBUG=True
+      # Required secrets - override via backend/.env file
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-insecure-jwt-key-for-local-docker-only}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-insecure-encryption-key-for-local-docker-only}
       # Add your API keys here or use .env file
       - ROOTLY_API_KEY=${ROOTLY_API_KEY:-}
       - PAGERDUTY_API_KEY=${PAGERDUTY_API_KEY:-}


### PR DESCRIPTION
## Summary
Remove insecure hardcoded default values for JWT_SECRET_KEY and ENCRYPTION_KEY from config.py. Both keys are now required environment variables.

## Changes
- Require JWT_SECRET_KEY and ENCRYPTION_KEY via environment variables
- Raise ValueError on startup if either key is missing
- Remove insecure placeholder values from .env.example
- Add documentation for key generation

## Breaking change
Before deploying, set both keys in Railway:

```bash
openssl rand -hex 32  # For JWT_SECRET_KEY (use different value per environment)
```

For ENCRYPTION_KEY, use existing value: `mf/89fRBkA7sZHpdDpidAyEKAUfm9VuT04ElWS37xaA=`

## Test plan
- [ ] Verify app fails to start without JWT_SECRET_KEY
- [ ] Verify app fails to start without ENCRYPTION_KEY
- [ ] Verify OAuth integrations still work