### PR TITLE
Fix: Flush survey_periods updates before deleting correlations

### DIFF
--- a/backend/app/services/user_sync_service.py
+++ b/backend/app/services/user_sync_service.py
@@ -659,6 +659,10 @@ class UserSyncService:
                 for period in survey_periods:
                     period.user_correlation_id = keep_record.id
 
+                # Flush to persist the updates before deleting
+                self.db.flush()
+                logger.info(f"    ✅ Flushed survey_periods updates to database")
+
             # Delete the duplicate record
             logger.info(f"    ❌ DELETING duplicate ID={dup.id}")
             self.db.delete(dup)


### PR DESCRIPTION
## Summary
Fixes continued NotNullViolation error when merging duplicate UserCorrelations.

## Problem
Even after PR #275 updated survey_periods foreign keys, SQLAlchemy's bidirectional relationship (backref) was still trying to NULL out the foreign keys during deletion, causing the constraint violation.

## Solution
Add `db.flush()` after updating survey_periods to force SQLAlchemy to persist the changes before the delete operation runs.

## Changes
- Add flush after updating survey_periods.user_correlation_id
- Add logging to confirm flush completed

## Test
User sync with duplicate correlations that have survey_periods now completes successfully.