### PR TITLE
Fix: Dialog z-index template literal not processed by Tailwind

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      `fixed inset-0 z-[${Z_INDEX.DIALOG}] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+      "fixed inset-0 z-[60] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        `fixed left-[50%] top-[50%] z-[${Z_INDEX.DIALOG}] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-neutral-300 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg`,
+        "fixed left-[50%] top-[50%] z-[60] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-neutral-300 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
## Problem
Sync team members modal appears behind the Sheet drawer despite `Z_INDEX.DIALOG` being set to 60.

## Root Cause
Tailwind's JIT compiler scans for **literal class names** at build time. Template literals like:
```jsx
className={`z-[${Z_INDEX.DIALOG}]`}
```
are **not processed** because Tailwind cannot evaluate JavaScript expressions. The class is ignored and defaults to z-50.

## Fix
Replace template literals with hardcoded values:
```jsx
// Before (doesn't work):
`z-[${Z_INDEX.DIALOG}]`

// After (works):
"z-[60]"
```

## Changes
- `DialogOverlay`: `z-[${Z_INDEX.DIALOG}]` → `z-[60]`
- `DialogContent`: `z-[${Z_INDEX.DIALOG}]` → `z-[60]`

## Why Not Use Inline Styles?
Could use `style={{zIndex: Z_INDEX.DIALOG}}` but that bypasses Tailwind's purging and optimization.

## Testing
Modal now correctly appears above drawer with z-60 vs drawer's z-50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)