### PR TITLE
Fix E2E test workflow for bot PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,8 @@ on:
 jobs:
   e2e-tests:
     name: E2E Tests (${{ matrix.browser }})
+    # Skip for Dependabot PRs - they don't have access to secrets for security
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -89,6 +91,8 @@ jobs:
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:3000
           PLAYWRIGHT_API_URL: ${{ secrets.PLAYWRIGHT_API_URL }}
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL_AVERY }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD_AVERY }}
           E2E_TEST_EMAIL_AVERY: ${{ secrets.E2E_TEST_EMAIL_AVERY }}
           E2E_TEST_PASSWORD_AVERY: ${{ secrets.E2E_TEST_PASSWORD_AVERY }}
           E2E_ROOTLY_API_KEY: ${{ secrets.E2E_ROOTLY_API_KEY }}


### PR DESCRIPTION
## Summary
- Skip E2E tests for Dependabot and Renovate PRs (they don't have access to secrets)
- Map E2E_TEST_EMAIL and E2E_TEST_PASSWORD to the AVERY secrets that tests expect

## Context
This completes the workflow fixes from PR #289. Dependabot PRs cannot access repository secrets due to GitHub security restrictions, so E2E tests must be skipped for bot actors.

The E2E tests look for `E2E_TEST_EMAIL` and `E2E_TEST_PASSWORD` environment variables, but our secrets are named `E2E_TEST_EMAIL_AVERY` and `E2E_TEST_PASSWORD_AVERY`. This PR maps them correctly for when tests do run on regular PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)