### PR TITLE
Fix: Ensure keep_record has ID before updating survey_periods FK

### DIFF
--- a/backend/app/services/user_sync_service.py
+++ b/backend/app/services/user_sync_service.py
@@ -682,6 +682,11 @@ class UserSyncService:
             ).all()
 
             if survey_periods:
+                # Ensure keep_record has an ID before using it as FK reference
+                if keep_record.id is None:
+                    self.db.flush()
+                    logger.info(f"    💾 Flushed keep_record to get ID: {keep_record.id}")
+
                 logger.info(f"    🔗 Updating {len(survey_periods)} survey_periods to reference ID={keep_record.id}")
                 for period in survey_periods:
                     period.user_correlation_id = keep_record.id

--- a/backend/app/services/user_sync_service.py
+++ b/backend/app/services/user_sync_service.py
@@ -395,11 +395,19 @@ class UserSyncService:
                 break
             except IntegrityError as e:
                 self.db.rollback()
-                if 'uq_user_correlation_user_email' in str(e.orig):
+                error_str = str(e.orig)
+                # Check for any of the UserCorrelation unique constraint violations
+                is_duplicate_key = any(constraint in error_str for constraint in [
+                    'uq_user_correlation_user_email',  # Old constraint (being removed)
+                    'uq_user_correlation_org_email_null_user',  # New: multi-tenant mode
+                    'uq_user_correlation_user_email_not_null'  # New: personal mode
+                ])
+
+                if is_duplicate_key:
                     if attempt < max_retries - 1:
                         logger.warning(
                             f"Duplicate key violation on commit (attempt {attempt+1}/{max_retries}). "
-                            f"Retrying after concurrent insert..."
+                            f"Retrying after concurrent insert... Error: {error_str}"
                         )
                         continue
                     else:

--- a/backend/app/services/user_sync_service.py
+++ b/backend/app/services/user_sync_service.py
@@ -691,9 +691,26 @@ class UserSyncService:
 
             if survey_periods:
                 # Ensure keep_record has an ID before using it as FK reference
+                # NOTE: flush() does NOT expose data to concurrent transactions in READ COMMITTED isolation.
+                # It only synchronizes SQLAlchemy's session with the current transaction's state.
+                # Other transactions remain isolated until commit(), where unique constraints enforce atomicity.
                 if keep_record.id is None:
-                    self.db.flush()
-                    logger.info(f"    💾 Flushed keep_record to get ID: {keep_record.id}")
+                    try:
+                        self.db.flush()
+                        # Verify ID was actually assigned
+                        if keep_record.id is None:
+                            raise ValueError(
+                                f"Failed to assign ID to keep_record after flush for {email}. "
+                                f"This indicates a database constraint violation or connection issue."
+                            )
+                        logger.info(f"    💾 Flushed keep_record to get ID: {keep_record.id}")
+                    except Exception as flush_error:
+                        logger.error(
+                            f"    ❌ Failed to flush keep_record for {email}: {flush_error}. "
+                            f"Cannot safely merge duplicates without valid ID."
+                        )
+                        # Re-raise to prevent FK updates with NULL ID
+                        raise
 
                 logger.info(f"    🔗 Updating {len(survey_periods)} survey_periods to reference ID={keep_record.id}")
                 for period in survey_periods:

--- a/backend/migrations/2026_02_02_add_partial_unique_constraints_user_correlation.sql
+++ b/backend/migrations/2026_02_02_add_partial_unique_constraints_user_correlation.sql
@@ -1,0 +1,153 @@
+-- Migration: Add partial unique constraints for UserCorrelation to prevent duplicates
+-- Date: 2026-02-02
+--
+-- Problem:
+-- The existing unique constraint uq_user_correlation_user_email UNIQUE (user_id, email)
+-- doesn't prevent duplicates in multi-tenant mode where user_id IS NULL.
+-- Team members (user_id=NULL) can have duplicate (organization_id, email) rows.
+--
+-- Solution:
+-- Add partial unique indexes to enforce uniqueness for both cases:
+-- 1. Multi-tenant: UNIQUE (organization_id, email) WHERE user_id IS NULL
+-- 2. Personal: UNIQUE (user_id, email) WHERE user_id IS NOT NULL
+
+-- Step 1: Check for and merge existing duplicates before adding constraints
+-- This prevents migration failure if duplicates already exist.
+
+DO $$
+DECLARE
+    dup_record RECORD;
+    keep_id INTEGER;
+    dup_count INTEGER := 0;
+BEGIN
+    -- Find and merge duplicates in multi-tenant mode (organization_id, email where user_id IS NULL)
+    FOR dup_record IN
+        SELECT organization_id, email, array_agg(id ORDER BY created_at DESC) as ids
+        FROM user_correlations
+        WHERE user_id IS NULL AND organization_id IS NOT NULL
+        GROUP BY organization_id, email
+        HAVING COUNT(*) > 1
+    LOOP
+        -- Keep the first ID (most recent by created_at)
+        keep_id := dup_record.ids[1];
+        dup_count := dup_count + 1;
+
+        RAISE NOTICE 'Merging % duplicates for org=% email=%: keeping id=%',
+            array_length(dup_record.ids, 1), dup_record.organization_id, dup_record.email, keep_id;
+
+        -- Update survey_periods to reference the kept record
+        UPDATE survey_periods
+        SET user_correlation_id = keep_id
+        WHERE user_correlation_id = ANY(dup_record.ids[2:array_length(dup_record.ids, 1)]);
+
+        -- Merge integration_ids arrays from duplicates into kept record
+        UPDATE user_correlations
+        SET integration_ids = (
+            SELECT ARRAY(
+                SELECT DISTINCT unnest(integration_ids)
+                FROM user_correlations
+                WHERE id = ANY(dup_record.ids)
+                AND integration_ids IS NOT NULL
+            )
+        )
+        WHERE id = keep_id;
+
+        -- Delete duplicate records (keep the first one)
+        DELETE FROM user_correlations
+        WHERE id = ANY(dup_record.ids[2:array_length(dup_record.ids, 1)]);
+    END LOOP;
+
+    -- Find and merge duplicates in personal mode (user_id, email where user_id IS NOT NULL)
+    FOR dup_record IN
+        SELECT user_id, email, array_agg(id ORDER BY created_at DESC) as ids
+        FROM user_correlations
+        WHERE user_id IS NOT NULL
+        GROUP BY user_id, email
+        HAVING COUNT(*) > 1
+    LOOP
+        -- Keep the first ID (most recent by created_at)
+        keep_id := dup_record.ids[1];
+        dup_count := dup_count + 1;
+
+        RAISE NOTICE 'Merging % duplicates for user_id=% email=%: keeping id=%',
+            array_length(dup_record.ids, 1), dup_record.user_id, dup_record.email, keep_id;
+
+        -- Update survey_periods to reference the kept record
+        UPDATE survey_periods
+        SET user_correlation_id = keep_id
+        WHERE user_correlation_id = ANY(dup_record.ids[2:array_length(dup_record.ids, 1)]);
+
+        -- Merge integration_ids arrays from duplicates into kept record
+        UPDATE user_correlations
+        SET integration_ids = (
+            SELECT ARRAY(
+                SELECT DISTINCT unnest(integration_ids)
+                FROM user_correlations
+                WHERE id = ANY(dup_record.ids)
+                AND integration_ids IS NOT NULL
+            )
+        )
+        WHERE id = keep_id;
+
+        -- Delete duplicate records (keep the first one)
+        DELETE FROM user_correlations
+        WHERE id = ANY(dup_record.ids[2:array_length(dup_record.ids, 1)]);
+    END LOOP;
+
+    IF dup_count > 0 THEN
+        RAISE NOTICE 'Merged and cleaned up % duplicate groups', dup_count;
+    ELSE
+        RAISE NOTICE 'No duplicates found - database is clean';
+    END IF;
+END $$;
+
+-- Step 2: Drop the old constraint if it exists
+-- The old constraint UNIQUE (user_id, email) doesn't properly handle NULL user_id cases
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'uq_user_correlation_user_email'
+    ) THEN
+        ALTER TABLE user_correlations
+        DROP CONSTRAINT uq_user_correlation_user_email;
+        RAISE NOTICE 'Dropped old constraint uq_user_correlation_user_email';
+    END IF;
+END $$;
+
+-- Step 3: Create partial unique index for multi-tenant mode (org-scoped roster)
+-- This prevents duplicate team members within an organization
+CREATE UNIQUE INDEX IF NOT EXISTS uq_user_correlation_org_email_null_user
+ON user_correlations (organization_id, email)
+WHERE user_id IS NULL;
+
+-- Step 4: Create partial unique index for personal mode (user-scoped)
+-- This prevents duplicate correlations for a specific user's personal records
+CREATE UNIQUE INDEX IF NOT EXISTS uq_user_correlation_user_email_not_null
+ON user_correlations (user_id, email)
+WHERE user_id IS NOT NULL;
+
+-- Step 5: Verify constraints are in place
+DO $$
+DECLARE
+    org_index_exists BOOLEAN;
+    user_index_exists BOOLEAN;
+BEGIN
+    -- Check if org-scoped index exists
+    SELECT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE indexname = 'uq_user_correlation_org_email_null_user'
+    ) INTO org_index_exists;
+
+    -- Check if user-scoped index exists
+    SELECT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE indexname = 'uq_user_correlation_user_email_not_null'
+    ) INTO user_index_exists;
+
+    IF org_index_exists AND user_index_exists THEN
+        RAISE NOTICE '✅ Both partial unique indexes are in place';
+    ELSE
+        RAISE WARNING '⚠️ One or both partial unique indexes are missing!';
+    END IF;
+END $$;


### PR DESCRIPTION
## Short-term Fix (Immediate)
Prevents NULL user_correlation_id when merging duplicates by ensuring `keep_record` is flushed to get its database ID before using it as a foreign key reference.

**Error prevented:**
```
null value in column "user_correlation_id" of relation "survey_periods" violates not-null constraint
```

## Long-term Fix (Root Cause)
Adds partial unique constraints to **prevent duplicates from being created in the first place**.

### Problem
Duplicates keep appearing due to race conditions during concurrent user syncs. The existing constraint only covers `(user_id, email)` but doesn't handle multi-tenant mode where `user_id IS NULL`.

### Solution
Database-level enforcement with partial unique indexes:

1. **Multi-tenant**: `UNIQUE (organization_id, email) WHERE user_id IS NULL`
2. **Personal**: `UNIQUE (user_id, email) WHERE user_id IS NOT NULL`

### Migration Safety
✅ Detects and merges existing duplicates before adding constraints
✅ Updates all survey_periods FK references during merge  
✅ Merges integration_ids arrays to preserve data
✅ Drops old incomplete constraint
✅ Verifies new indexes are created successfully

### Code Changes
Updated IntegrityError handling to recognize new constraint names and retry gracefully on conflicts.

### Why This is the Final Fix
- Database enforces uniqueness atomically (no race condition window)
- No application-level locking needed (simpler, more performant)
- Existing retry logic handles conflicts gracefully
- Prevents the issue from recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)