### PR TITLE
Remove burnout terminology and rename API fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The frontend will be available at `http://localhost:3000`
 
 ##  Methodology
 
-On-call Health takes inspiration from the [Copenhagen Burnout Inventory](https://nfa.dk/media/hl5nbers/cbi-first-edition.pdf) (CBI), a scientifically validated approach to measuring overwork risk in professional settings. On-call Health isn't a medical tool and doesn't provide a diagnosis; it is designed to help identify patterns and trends that may suggest overwork.
+On-call Health uses a scientifically informed approach to measuring overwork risk in professional settings. On-call Health isn't a medical tool and doesn't provide a diagnosis; it is designed to help identify patterns and trends that may suggest overwork.
 
 ### Methodology breakdown
 Our implementation uses the two core dimensions:

--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -22,6 +22,22 @@ from ...utils.visual_logger import log_task_start, log_task_complete
 logger = logging.getLogger(__name__)
 
 
+def sanitize_burnout_score_from_response(analysis_data: Optional[dict]) -> Optional[dict]:
+    """
+    No-op function for compatibility with analysis.py imports.
+
+    We've renamed burnout_score to health_score, so no sanitization needed.
+    This function exists only to maintain import compatibility.
+
+    Args:
+        analysis_data: The analysis data dict
+
+    Returns:
+        The same dict unchanged (health_score is kept)
+    """
+    return analysis_data
+
+
 def extract_analysis_summary(full_results: dict) -> dict:
     """
     Extract lightweight summary data from full analysis results.

--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -985,6 +985,7 @@ async def regenerate_analysis_trends(
             daily_trends.append({
                 "date": current_date.strftime("%Y-%m-%d"),
                 "overall_score": round(daily_score, 2),
+                "average_health_score": 0.0,  # Legacy analyses don't have this data
                 "incident_count": incidents_for_day,
                 "members_at_risk": members_at_risk,
                 "total_members": total_members,

--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -109,7 +109,7 @@ class AnalysisListResponse(BaseModel):
 class DailyTrendPoint(BaseModel):
     date: str
     overall_score: float
-    average_burnout_score: float
+    average_health_score: float
     members_at_risk: int
     total_members: int
     health_status: str
@@ -926,7 +926,7 @@ async def regenerate_analysis_trends(
         # Calculate some basic metrics from existing data
         total_members = len(members)
         members_with_incidents = [m for m in members if m.get("incident_count", 0) > 0]
-        avg_burnout_score = sum(m.get("burnout_score", 0) for m in members) / max(total_members, 1)
+        avg_health_score = sum(m.get("health_score", 0) for m in members) / max(total_members, 1)
         
         # Generate daily trends
         daily_trends = []
@@ -951,9 +951,9 @@ async def regenerate_analysis_trends(
             
             incidents_distributed += incidents_for_day
             
-            # Calculate health score based on burnout analysis
+            # Calculate health score based on health analysis
             # Higher incident days = lower health scores
-            base_score = avg_burnout_score / 10  # Convert to 0-10 scale
+            base_score = avg_health_score / 10  # Convert to 0-10 scale
             if incidents_for_day > 5:
                 daily_score = max(0.3, base_score - 0.2)
             elif incidents_for_day > 2:
@@ -1354,7 +1354,7 @@ async def get_historical_trends(
         daily_trends.append(DailyTrendPoint(
             date=trend_date,
             overall_score=float(overall_score),
-            average_burnout_score=float(trend_data.get("overall_score", 0.0)),  # Use same score for consistency
+            average_health_score=float(trend_data.get("overall_score", 0.0)),  # Use same score for consistency
             members_at_risk=int(members_at_risk),
             total_members=max(int(total_members), 1),  # Use actual total_members from analysis
             health_status=health_status,

--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -942,7 +942,8 @@ async def regenerate_analysis_trends(
         # Calculate some basic metrics from existing data
         total_members = len(members)
         members_with_incidents = [m for m in members if m.get("incident_count", 0) > 0]
-        avg_health_score = sum(m.get("health_score", 0) for m in members) / max(total_members, 1)
+        # Use och_score (0-100) as primary metric, not health_score which may be 0
+        avg_och_score = sum(m.get("och_score", 0) for m in members) / max(total_members, 1)
         
         # Generate daily trends
         daily_trends = []
@@ -969,7 +970,7 @@ async def regenerate_analysis_trends(
             
             # Calculate health score based on health analysis
             # Higher incident days = lower health scores
-            base_score = avg_health_score / 10  # Convert to 0-10 scale
+            base_score = avg_och_score / 10  # Convert OCH (0-100) to 0-10 scale
             if incidents_for_day > 5:
                 daily_score = max(0.3, base_score - 0.2)
             elif incidents_for_day > 2:
@@ -1370,7 +1371,7 @@ async def get_historical_trends(
         daily_trends.append(DailyTrendPoint(
             date=trend_date,
             overall_score=float(overall_score),
-            average_health_score=float(trend_data.get("overall_score", 0.0)),  # Use same score for consistency
+            average_health_score=float(trend_data.get("average_health_score", 0.0)),  # Actual average from team health
             members_at_risk=int(members_at_risk),
             total_members=max(int(total_members), 1),  # Use actual total_members from analysis
             health_status=health_status,

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -50,7 +50,7 @@ async def analysis_start(
     include_weekends: bool = True,
     integration_id: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Start a new burnout analysis."""
+    """Start a new health analysis."""
     api_key = get_api_key()
     if not api_key:
         raise PermissionError("Missing API key. Provide X-API-Key header.")
@@ -190,10 +190,9 @@ async def integrations_list() -> Dict[str, Any]:
 def methodology_resource() -> str:
     """Provide a short methodology description."""
     return (
-        "On-Call Health measures overwork risk using a two-dimensional model inspired by the "
-        "Copenhagen Burnout Inventory. It combines objective workload signals (incidents, "
-        "communications, commits) with self-reported data to surface risk patterns without "
-        "providing medical diagnosis."
+        "On-Call Health measures overwork risk using a scientifically informed two-dimensional "
+        "model. It combines objective workload signals (incidents, communications, commits) "
+        "with self-reported data to surface risk patterns without providing medical diagnosis."
     )
 
 

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -1134,7 +1134,7 @@ class UnifiedBurnoutAnalyzer:
                         logger.info(f"Member details:")
                         for member in members[:5]:  # Show first 5
                             name = member.get('name', 'Unknown')
-                            score = member.get('burnout_score', 'N/A')
+                            score = member.get('health_score', 'N/A')
                             risk = member.get('risk_level', 'N/A')
                             has_github = 'github_insights' in member
                             has_slack = 'slack_insights' in member
@@ -1471,7 +1471,7 @@ class UnifiedBurnoutAnalyzer:
             member_analyses.append(user_analysis)
         
         # Sort by burnout score (highest first)
-        member_analyses.sort(key=lambda x: x["burnout_score"], reverse=True)
+        member_analyses.sort(key=lambda x: x["health_score"], reverse=True)
 
         # Count only incidents that were actually assigned to team members
         assigned_incident_ids = set()
@@ -1668,7 +1668,7 @@ class UnifiedBurnoutAnalyzer:
                 "rootly_user_id": rootly_user_id,  # Include Rootly mapping for logo display
                 "pagerduty_user_id": pagerduty_user_id,  # Include PagerDuty mapping for logo display
                 "avatar_url": avatar_url,  # Profile image URL from PagerDuty/Rootly
-                "burnout_score": 0,
+                "health_score": 0,
                 "och_score": round(min(100, composite_och['composite_score']), 2),  # Cap display at 100 for UI
                 "risk_level": "low",
                 "incident_count": 0,
@@ -1945,7 +1945,7 @@ class UnifiedBurnoutAnalyzer:
             "rootly_user_id": rootly_user_id,  # Include Rootly mapping for logo display
             "pagerduty_user_id": pagerduty_user_id,  # Include PagerDuty mapping for logo display
             "avatar_url": avatar_url,  # Profile image URL from PagerDuty/Rootly
-            "burnout_score": round(burnout_score, 2),
+            "health_score": round(burnout_score, 2),
             "och_score": round(min(100, composite_och['composite_score']), 2),  # Cap display at 100 for UI
             "risk_level": risk_level,
             "incident_count": len(incidents),
@@ -3152,7 +3152,7 @@ class UnifiedBurnoutAnalyzer:
             logger.info(f"Team health calculation using OCH scores: avg={avg_burnout:.1f}, count={len(och_scores)}")
         else:
             # Fallback to legacy burnout scores (0-10 scale where higher = more burnout)
-            legacy_scores = [m.get("burnout_score", 0) for m in eligible_members if m and isinstance(m, dict) and m.get("burnout_score") is not None]
+            legacy_scores = [m.get("health_score", 0) for m in eligible_members if m and isinstance(m, dict) and m.get("health_score") is not None]
             avg_burnout = sum(legacy_scores) / len(legacy_scores) if legacy_scores and len(legacy_scores) > 0 else 0
             using_och = False
             logger.info(f"Team health calculation using legacy scores: avg={avg_burnout:.1f}, count={len(legacy_scores)}")
@@ -3390,7 +3390,7 @@ class UnifiedBurnoutAnalyzer:
         
         # Add specific dimension-based recommendations
         if members:
-            high_burnout_members = [m for m in members if m.get("burnout_score", 0) >= 7.0]
+            high_burnout_members = [m for m in members if m.get("health_score", 0) >= 7.0]
             if high_burnout_members:
                 recommendations.append({
                     "type": "personal_burnout",
@@ -4680,7 +4680,7 @@ class UnifiedBurnoutAnalyzer:
                     continue
                 
                 # Get current burnout info
-                current_score = member.get("burnout_score", 0)
+                current_score = member.get("health_score", 0)
                 incident_count = member.get("incident_count", 0)
                 github_activity = member.get("github_activity", {})
                 
@@ -4734,7 +4734,7 @@ class UnifiedBurnoutAnalyzer:
                 
                 # Update member with new score
                 updated_member = member.copy()
-                updated_member["burnout_score"] = round(final_score, 2)
+                updated_member["health_score"] = round(final_score, 2)
                 updated_member["risk_level"] = self._determine_risk_level(final_score)
                 
                 # Add GitHub burnout breakdown for transparency

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -1731,18 +1731,18 @@ class UnifiedBurnoutAnalyzer:
         
         # OCH DEBUG LOGGING - Removed to reduce Railway log noise
         
-        # Calculate overall burnout score using three-factor methodology (equal weighting)
-        burnout_score = (dimensions["personal_burnout"] * 0.333 + 
-                        dimensions["work_related_burnout"] * 0.333 + 
+        # Calculate overall health score using three-factor methodology (equal weighting)
+        health_score = (dimensions["personal_burnout"] * 0.333 +
+                        dimensions["work_related_burnout"] * 0.333 +
                         dimensions["accomplishment_burnout"] * 0.334)
-        
+
         # Ensure overall score is never negative
-        burnout_score = max(0, burnout_score)
-        
+        health_score = max(0, health_score)
+
         # Debug logging removed to reduce noise
-        
+
         # Determine risk level
-        risk_level = self._determine_risk_level(burnout_score)
+        risk_level = self._determine_risk_level(health_score)
         
         # Calculate OCH (On-Call Health) score
         # Map existing metrics to OCH format with severity weighting
@@ -1945,7 +1945,7 @@ class UnifiedBurnoutAnalyzer:
             "rootly_user_id": rootly_user_id,  # Include Rootly mapping for logo display
             "pagerduty_user_id": pagerduty_user_id,  # Include PagerDuty mapping for logo display
             "avatar_url": avatar_url,  # Profile image URL from PagerDuty/Rootly
-            "health_score": round(burnout_score, 2),
+            "health_score": round(health_score, 2),
             "och_score": round(min(100, composite_och['composite_score']), 2),  # Cap display at 100 for UI
             "risk_level": risk_level,
             "incident_count": len(incidents),

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -3129,7 +3129,7 @@ class UnifiedBurnoutAnalyzer:
             return {
                 "overall_score": 6.5,  # Neutral baseline if no data (not perfect health)
                 "risk_distribution": {"low": 0, "medium": 0, "high": 0, "critical": 0},
-                "average_burnout_score": 0,
+                "average_health_score": 0,
                 "health_status": "fair",
                 "members_at_risk": 0
             }
@@ -3209,7 +3209,7 @@ class UnifiedBurnoutAnalyzer:
             "overall_score": round(overall_score, 2),
             "scoring_method": "OCH" if using_och else "Legacy",
             "risk_distribution": risk_dist,
-            "average_burnout_score": round(avg_burnout, 2),
+            "average_health_score": round(avg_burnout, 2),
             "health_status": health_status,
             "members_at_risk": risk_dist["high"] + risk_dist["critical"]
         }

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -3142,20 +3142,20 @@ class UnifiedBurnoutAnalyzer:
         eligible_members = members_with_incidents  # Only those with actual incident activity
         logger.info(f"🏥 TEAM_HEALTH: Filtering to {len(eligible_members)} members with incidents (from {len(member_analyses)} total)")
         
-        # Calculate average burnout for ELIGIBLE members only - prioritize OCH scores when available  
+        # Calculate average score for ELIGIBLE members only - prioritize OCH scores when available
         och_scores = [m.get("och_score") for m in eligible_members if m and isinstance(m, dict) and m.get("och_score") is not None]
-        
+
         if och_scores and len(och_scores) > 0:
-            # Use OCH scores (0-100 scale where higher = more burnout)
-            avg_burnout = sum(och_scores) / len(och_scores)
+            # Use OCH scores (0-100 scale where higher = more health risk)
+            avg_score = sum(och_scores) / len(och_scores)
             using_och = True
-            logger.info(f"Team health calculation using OCH scores: avg={avg_burnout:.1f}, count={len(och_scores)}")
+            logger.info(f"Team health calculation using OCH scores: avg={avg_score:.1f}, count={len(och_scores)}")
         else:
-            # Fallback to legacy burnout scores (0-10 scale where higher = more burnout)
+            # Fallback to legacy health scores (0-10 scale where higher = more health risk)
             legacy_scores = [m.get("health_score", 0) for m in eligible_members if m and isinstance(m, dict) and m.get("health_score") is not None]
-            avg_burnout = sum(legacy_scores) / len(legacy_scores) if legacy_scores and len(legacy_scores) > 0 else 0
+            avg_score = sum(legacy_scores) / len(legacy_scores) if legacy_scores and len(legacy_scores) > 0 else 0
             using_och = False
-            logger.info(f"Team health calculation using legacy scores: avg={avg_burnout:.1f}, count={len(legacy_scores)}")
+            logger.info(f"Team health calculation using legacy scores: avg={avg_score:.1f}, count={len(legacy_scores)}")
         
         # Count risk levels (updated for 4-tier system) - ONLY include eligible members with incidents
         risk_dist = {"low": 0, "medium": 0, "high": 0, "critical": 0}
@@ -3169,27 +3169,27 @@ class UnifiedBurnoutAnalyzer:
         
         # Calculate overall health score using appropriate scale
         if using_och:
-            # OCH scoring (0-100 where higher = more burnout)
+            # OCH scoring (0-100 where higher = more health risk)
             # Store raw OCH score as overall_score for frontend consumption
-            overall_score = avg_burnout
+            overall_score = avg_score
             logger.info(f"Using raw OCH score as overall_score: {overall_score}")
         else:
-            # Legacy scoring - convert 0-10 burnout to 0-10 health scale (inverse)
-            overall_score = 10 - avg_burnout
+            # Legacy scoring - convert 0-10 health risk to 0-10 health scale (inverse)
+            overall_score = 10 - avg_score
             overall_score = max(0, overall_score)
-            logger.info(f"Using legacy health calculation: burnout={avg_burnout} -> health={overall_score}")
+            logger.info(f"Using legacy health calculation: health_risk={avg_score} -> health={overall_score}")
         
         # Determine health status based on scoring method
         if using_och:
-            # OCH scoring (0-100 where higher = more burnout)
+            # OCH scoring (0-100 where higher = more health risk)
             if overall_score < 25:
-                health_status = "excellent"  # Low/minimal burnout
+                health_status = "excellent"  # Low/minimal health risk
             elif overall_score < 50:
-                health_status = "good"       # Mild burnout symptoms  
+                health_status = "good"       # Mild health risk
             elif overall_score < 75:
-                health_status = "fair"       # Moderate burnout risk
+                health_status = "fair"       # Moderate health risk
             else:
-                health_status = "poor"       # High/severe burnout risk
+                health_status = "poor"       # High/severe health risk
             logger.info(f"OCH health status: score={overall_score} -> {health_status}")
         else:
             # Legacy scoring (0-10 health scale where higher = better health)
@@ -3204,12 +3204,12 @@ class UnifiedBurnoutAnalyzer:
             else:  # <60%
                 health_status = "critical"
             logger.info(f"Legacy health status: score={overall_score} -> {health_status}")
-        
+
         return {
             "overall_score": round(overall_score, 2),
             "scoring_method": "OCH" if using_och else "Legacy",
             "risk_distribution": risk_dist,
-            "average_health_score": round(avg_burnout, 2),
+            "average_health_score": round(avg_score, 2),
             "health_status": health_status,
             "members_at_risk": risk_dist["high"] + risk_dist["critical"]
         }

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -4390,6 +4390,7 @@ class UnifiedBurnoutAnalyzer:
                 daily_trends.append({
                     "date": date_str,
                     "overall_score": round(daily_score, 2),  # Keep as 0-10 scale (SimpleBurnoutAnalyzer approach)
+                    "average_health_score": team_health.get("average_health_score", 0.0) if team_health else 0.0,
                     "incident_count": incident_count,
                     "severity_weighted_count": round(severity_weighted, 1),
                     "after_hours_count": after_hours_count,

--- a/backend/tests/test_unified_burnout_analyzer_integration.py
+++ b/backend/tests/test_unified_burnout_analyzer_integration.py
@@ -418,7 +418,7 @@ class TestCalculationMethods:
         # Check correct key names
         assert "overall_score" in result
         assert "scoring_method" in result
-        assert "average_burnout_score" in result  # NOT "average_burnout"
+        assert "average_health_score" in result  # NOT "average_burnout"
         assert "health_status" in result
         assert "risk_distribution" in result
         assert "members_at_risk" in result

--- a/frontend/src/app/dashboard/analyses.json
+++ b/frontend/src/app/dashboard/analyses.json
@@ -44,7 +44,7 @@
                 "high": 1,
                 "critical": 0
             },
-            "average_burnout_score": 0,
+            "average_health_score": 0,
             "health_status": "excellent",
             "members_at_risk": 1
         },
@@ -8713,7 +8713,7 @@
                     "primary_concern": "1 team member(s) showing severe OCH burnout symptoms (>75/100) requiring immediate intervention",
                     "key_metrics": {
                         "total_team_incidents": 0,
-                        "average_burnout_score": 0,
+                        "average_health_score": 0,
                         "scoring_methodology": "OCH (0-100)",
                         "high_risk_percentage": 2.4390243902439024,
                         "data_completeness": 1

--- a/frontend/src/app/methodology/page.tsx
+++ b/frontend/src/app/methodology/page.tsx
@@ -26,7 +26,7 @@ const content = {
   // Page header
   header: {
     title: "On-Call Health Methodology",
-    subtitle: "Research-enhanced Copenhagen Burnout Inventory with compound trauma, time impact, and recovery analysis",
+    subtitle: "Research-enhanced health assessment with compound trauma, time impact, and recovery analysis",
   },
 
   // Goal and Role section - redesigned with cards
@@ -40,7 +40,7 @@ const content = {
       iconColor: "text-blue-600",
       title: "What On-Call Health Is For",
       description: `The goal of On-Call Health is to help incident management organizations maintain a healthy and sustainable on-call and workload balance for incident responders. Instead of reacting once people are already exhausted, the tool is designed to surface early signs that teams or individuals may be drifting into overload.`,
-      callout: `On-Call Health is not a medical device and does not diagnose burnout or mental health conditions. Its role is to provide visibility into workload patterns and trends, so teams can notice issues sooner, ask better questions, and take corrective action before problems escalate.`,
+      callout: `On-Call Health is not a medical device and does not diagnose mental health conditions. Its role is to provide visibility into workload patterns and trends, so teams can notice issues sooner, ask better questions, and take corrective action before problems escalate.`,
       calloutColor: "blue",
     },
 
@@ -116,7 +116,7 @@ const content = {
     title: "The Method Behind <em>Risk Level</em>",
     description: "A baseline-driven overload signal inspired by established research",
     paragraphs: [
-      `On-Call Health computes a composite signal called <strong>Risk Level</strong>, derived from multiple <strong>Risk Signals</strong> and designed for engineering on-call and incident response work. The scoring approach is informed by established workload and burnout research, including the Copenhagen Burnout Inventory (CBI), but it is adapted to operational telemetry rather than survey-only measurement. Risk Level is not a medical tool and should not be used for diagnosis—its purpose is to surface <strong>trend drift</strong> that may indicate unsustainable on-call load.`,
+      `On-Call Health computes a composite signal called <strong>Risk Level</strong>, derived from multiple <strong>Risk Signals</strong> and designed for engineering on-call and incident response work. The scoring approach is informed by established workload and health research, adapted to operational telemetry rather than survey-only measurement. Risk Level is not a medical tool and should not be used for diagnosis—its purpose is to surface <strong>trend drift</strong> that may indicate unsustainable on-call load.`,
       `The composite signal incorporates factors such as incident volume and severity, after-hours and weekend interruptions, and sustained periods of elevated operational activity. These inputs are evaluated over time and interpreted relative to individual and team baselines, because what is "normal" varies significantly across organizations and responders.`,
     ],
     callout: `<strong>Multi-Source Analysis:</strong> On-Call Health can ingest signals from tools like Rootly and PagerDuty as primary sources, with additional context from GitHub, Slack, Linear, and Jira when available. The model adapts to whichever integrations you enable, providing visibility into workload patterns without requiring a single "perfect" data source.`,
@@ -198,7 +198,7 @@ const content = {
         iconColor: "text-blue-600",
         title: "Recovery Deficit Analysis",
         description: `Psychological recovery research shows that insufficient time between stressful incidents prevents proper mental restoration. Recovery periods under 48 hours significantly impair the brain's ability to process and recover from traumatic stress.`,
-        researchBasis: `Trauma psychology research demonstrates that recovery periods <48 hours prevent psychological restoration, leading to stress accumulation and increased burnout risk.`,
+        researchBasis: `Trauma psychology research demonstrates that recovery periods <48 hours prevent psychological restoration, leading to stress accumulation and increased health risk.`,
         researchColor: "blue",
         detail: `<strong>Scoring:</strong> Recovery Score 0-100 (higher = better) • Perfect recovery: 168+ hours between incidents • Each violation (<48 hours) reduces recovery adequacy • Sustained violations indicate chronic stress`,
       },
@@ -207,23 +207,23 @@ const content = {
 
   // Dimensions section
   dimensions: {
-    title: "On-Call Burnout Dimensions (OCH Methodology)",
-    description: "Based on the Copenhagen Burnout Inventory - two dimensions specifically adapted for software engineers",
+    title: "On-Call Health Dimensions (OCH Methodology)",
+    description: "Two dimensions specifically adapted for software engineers on-call work",
     items: [
       {
         color: "red",
-        title: "Personal Burnout (65% weight)",
+        title: "Personal Wellbeing (65% weight)",
         description: `Physical and psychological fatigue and exhaustion experienced by the person. This dimension measures recovery time interference, work-life balance erosion, and psychological impact from high-stress incidents.`,
         calculation: "After-Hours Activity (30%) + High-Severity Incident Impact (25%) + Task Load (10%)",
       },
       {
         color: "yellow",
-        title: "Work-Related Burnout (35% weight)",
+        title: "Work-Related Wellbeing (35% weight)",
         description: `Fatigue and exhaustion specifically attributed to work demands. This dimension captures on-call burden, sustained stress from consecutive incident days, and workload pressure.`,
         calculation: "On-Call Load (20%) + Consecutive Incident Days (15%)",
       },
     ],
-    footer: `<strong>Final Score:</strong> The two dimensions are weighted and combined to produce a final burnout score from 0-100, with higher scores indicating greater burnout risk. The OCH methodology reflects research showing that personal factors (work-life balance) contribute more to burnout than work-specific factors alone.`,
+    footer: `<strong>Final Score:</strong> The two dimensions are weighted and combined to produce a final health score from 0-100, with higher scores indicating greater health risk. The OCH methodology reflects research showing that personal factors (work-life balance) contribute more to health risk than work-specific factors alone.`,
   },
 }
 
@@ -252,7 +252,7 @@ const sections = [
   { id: "method", title: "The Method Behind Risk Level" },
   { id: "workload-signals", title: "Risk Signals" },
   { id: "research-enhancements", title: "Risk Level Formula" },
-  { id: "burnout-dimensions", title: "Burnout Dimensions" },
+  { id: "health-dimensions", title: "Health Dimensions" },
 ]
 
 export default function MethodologyPage() {
@@ -502,7 +502,7 @@ export default function MethodologyPage() {
         </div>
 
         {/* Three Dimensions */}
-        <Card id="burnout-dimensions" className="mb-8 scroll-mt-8">
+        <Card id="health-dimensions" className="mb-8 scroll-mt-8">
           <CardHeader>
             <CardTitle>{content.dimensions.title}</CardTitle>
             <CardDescription>{content.dimensions.description}</CardDescription>

--- a/frontend/src/components/dashboard/TeamMembersList.tsx
+++ b/frontend/src/components/dashboard/TeamMembersList.tsx
@@ -225,7 +225,7 @@ export function TeamMembersList({
         name: member.user_name || 'Unknown',
         email: member.user_email || '',
         avatar_url: member.avatar_url || null,
-        burnoutScore: member.och_score || 0,
+        healthScore: member.och_score || 0,
         riskLevel: (member.risk_level || 'low') as 'high' | 'medium' | 'low',
         trend: trendInfo.trend,
         trendPercentage: trendInfo.percentage,

--- a/frontend/src/components/dashboard/TeamMembersList.tsx
+++ b/frontend/src/components/dashboard/TeamMembersList.tsx
@@ -193,7 +193,7 @@ export function TeamMembersList({
   
   const isLoading = !currentAnalysis || !currentAnalysis.analysis_data
 
-  // OCH risk level from score (0-100 scale, higher = more burnout)
+  // OCH risk level from score (0-100 scale, higher = more health risk)
   function getOCHRiskLevel(score: number | undefined | null): string {
     if (score === undefined || score === null) return 'low'
     if (score < 25) return 'healthy'
@@ -202,13 +202,13 @@ export function TeamMembersList({
     return 'critical'
   }
 
-  // OCH 4-color system for progress bars (0-100 scale, higher = more burnout)
+  // OCH 4-color system for progress bars (0-100 scale, higher = more health risk)
   function getOCHProgressColor(score: number): string {
     const clampedScore = Math.max(0, Math.min(100, score))
-    if (clampedScore < 25) return '#10b981'  // Green - Low/minimal burnout (0-24)
-    if (clampedScore < 50) return '#eab308'  // Yellow - Mild burnout symptoms (25-49)
-    if (clampedScore < 75) return '#f97316'  // Orange - Moderate/significant burnout (50-74)
-    return '#dc2626'                          // Red - High/severe burnout (75-100)
+    if (clampedScore < 25) return '#10b981'  // Green - Low/minimal health risk (0-24)
+    if (clampedScore < 50) return '#eab308'  // Yellow - Mild health risk (25-49)
+    if (clampedScore < 75) return '#f97316'  // Orange - Moderate/significant health risk (50-74)
+    return '#dc2626'                          // Red - High/severe health risk (75-100)
   }
 
   const renderMemberCard = (member: any) => {
@@ -402,7 +402,7 @@ export function TeamMembersList({
               return member.och_score !== undefined && member.och_score !== null
             })
             
-            // Separate members with incidents/burnout and those with neither
+            // Separate members with incidents/health risk and those with neither
             // Include members with incidents OR OCH risk level (e.g., from Jira) in main section
             const membersWithIncidents = validMembers.filter(member =>
               (member.incident_count || 0) > 0 || (member.och_score || 0) > 0
@@ -428,14 +428,14 @@ export function TeamMembersList({
 
             return (
               <>
-                {/* Members with incidents or burnout (from Jira, GitHub, etc.) */}
+                {/* Members with incidents or health risk (from Jira, GitHub, etc.) */}
                 {membersWithIncidents.length > 0 && (
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
                     {sortMembers(membersWithIncidents).map(renderMemberCard)}
                   </div>
                 )}
 
-                {/* Collapsible section for members with no activity (no incidents and no burnout) */}
+                {/* Collapsible section for members with no activity (no incidents and no health risk) */}
                 {(membersWithoutIncidents.length > 0 || isLoading) && (
                   <div className="mt-6">
                     <Button

--- a/frontend/src/components/dashboard/TeamMembersList.tsx
+++ b/frontend/src/components/dashboard/TeamMembersList.tsx
@@ -211,14 +211,14 @@ export function TeamMembersList({
     return '#dc2626'                          // Red - High/severe health risk (75-100)
   }
 
-  const renderMemberCard = (member: any) => {
+  const renderMemberCard = (member: any, index: number) => {
     // Calculate user trend from individual daily data
     const trendInfo = calculateUserTrend(member.user_email, individualDailyData)
     const trendConfig = getTrendConfig(trendInfo.trend)
 
     return (
     <Card
-      key={`${member.user_email}-${member.user_id || 'no-id'}`}
+      key={`member-${index}-${member.user_email}`}
       className="cursor-pointer hover:shadow-md transition-shadow"
       onClick={() => setSelectedMember({
         id: member.user_id || '',

--- a/frontend/src/components/dashboard/TeamMembersList.tsx
+++ b/frontend/src/components/dashboard/TeamMembersList.tsx
@@ -218,7 +218,7 @@ export function TeamMembersList({
 
     return (
     <Card
-      key={member.user_email || member.user_id}
+      key={`${member.user_email}-${member.user_id || 'no-id'}`}
       className="cursor-pointer hover:shadow-md transition-shadow"
       onClick={() => setSelectedMember({
         id: member.user_id || '',

--- a/frontend/src/components/dashboard/TicketingCard.tsx
+++ b/frontend/src/components/dashboard/TicketingCard.tsx
@@ -21,10 +21,10 @@ function truncateTitle(title: string, limit: number = TITLE_CHARACTER_LIMIT): st
   return title.substring(0, limit) + "..."
 }
 
-// Helper function to determine priority badge color (matches burnout analysis colors exactly)
+// Helper function to determine priority badge color (matches health analysis colors exactly)
 function getPriorityColor(priority: string | number): { backgroundColor: string; color: string } {
   if (typeof priority === "string") {
-    // Jira priority - matches burnout analysis severity colors
+    // Jira priority - matches health analysis severity colors
     switch (priority.toLowerCase()) {
       case "highest":
         return { backgroundColor: "#EF4444", color: "white" } // Critical
@@ -40,7 +40,7 @@ function getPriorityColor(priority: string | number): { backgroundColor: string;
         return { backgroundColor: "#9CA3AF", color: "white" }
     }
   } else {
-    // Linear priority (1=Urgent, 2=High, 3=Medium, 4=Low, 0=None) - matches burnout analysis severity colors
+    // Linear priority (1=Urgent, 2=High, 3=Medium, 4=Low, 0=None) - matches health analysis severity colors
     switch (priority) {
       case 1:
         return { backgroundColor: "#EF4444", color: "white" } // Critical

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -2133,32 +2133,32 @@ export default function useDashboard() {
         return memberWithOch.och_score !== undefined && memberWithOch.och_score !== null && memberWithOch.och_score > 0
       })
       ?.map((member) => {
-        // Use OCH scoring system (0-100 scale, higher = more burnout)
+        // Use OCH scoring system (0-100 scale, higher = more health risk)
         const score = (member as any).och_score || 0
-        
-        const burnoutScore = Math.max(0, score);
-        
-        // Official OCH 4-color system based on burnout score (higher = worse)
-        const getRiskFromBurnoutScore = (burnoutScore: number) => {
-          if (burnoutScore < 25) return { level: 'low', color: '#10b981' };      // Green - Low/minimal burnout (0-24)
-          if (burnoutScore < 50) return { level: 'mild', color: '#eab308' };     // Yellow - Mild burnout symptoms (25-49)  
-          if (burnoutScore < 75) return { level: 'moderate', color: '#f97316' }; // Orange - Moderate/significant burnout (50-74)
-          return { level: 'high', color: '#dc2626' };                           // Red - High/severe burnout (75-100)
+
+        const healthScore = Math.max(0, score);
+
+        // Official OCH 4-color system based on health score (higher = worse)
+        const getRiskFromHealthScore = (healthScore: number) => {
+          if (healthScore < 25) return { level: 'low', color: '#10b981' };      // Green - Low/minimal health risk (0-24)
+          if (healthScore < 50) return { level: 'mild', color: '#eab308' };     // Yellow - Mild health risk (25-49)
+          if (healthScore < 75) return { level: 'moderate', color: '#f97316' }; // Orange - Moderate/significant health risk (50-74)
+          return { level: 'high', color: '#dc2626' };                           // Red - High/severe health risk (75-100)
         };
-        
-        const riskInfo = getRiskFromBurnoutScore(burnoutScore);
-        
+
+        const riskInfo = getRiskFromHealthScore(healthScore);
+
         return {
           name: member.user_name.split(" ")[0],
           fullName: member.user_name,
-          score: burnoutScore,
+          score: healthScore,
           riskLevel: riskInfo.level,
           backendRiskLevel: member.risk_level, // Keep original for reference
           scoreType: 'OCH',
           fill: riskInfo.color,
         }
       })
-      ?.sort((a, b) => b.score - a.score) // Sort by score descending (highest burnout first)
+      ?.sort((a, b) => b.score - a.score) // Sort by score descending (highest health risk first)
       || []
   })();
   

--- a/packages/oncallhealth-mcp/src/oncallhealth_mcp/__init__.py
+++ b/packages/oncallhealth-mcp/src/oncallhealth_mcp/__init__.py
@@ -1,8 +1,8 @@
 """
-oncallhealth-mcp: MCP server for On-Call Health burnout analysis.
+oncallhealth-mcp: MCP server for On-Call Health analysis.
 
 This package provides an MCP (Model Context Protocol) server that enables
-AI assistants to access On-Call Health burnout analysis features.
+AI assistants to access On-Call Health analysis features.
 
 Usage:
     # Run via uvx (recommended)

--- a/packages/oncallhealth-mcp/src/oncallhealth_mcp/cli.py
+++ b/packages/oncallhealth-mcp/src/oncallhealth_mcp/cli.py
@@ -12,7 +12,7 @@ def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         prog="oncallhealth-mcp",
-        description="MCP server for On-Call Health burnout analysis",
+        description="MCP server for On-Call Health analysis",
     )
     parser.add_argument(
         "--transport",

--- a/packages/oncallhealth-mcp/src/oncallhealth_mcp/server.py
+++ b/packages/oncallhealth-mcp/src/oncallhealth_mcp/server.py
@@ -63,7 +63,7 @@ async def analysis_start(
     include_weekends: bool = True,
     integration_id: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Start a new burnout analysis."""
+    """Start a new health analysis."""
     api_key = _validate_api_key(ctx)
 
     if days_back <= 0:
@@ -297,7 +297,7 @@ async def get_at_risk_users(
     min_och_score: float = 50.0,
     include_risk_levels: Optional[str] = "medium,high"
 ) -> Dict[str, Any]:
-    """Get users at or above burnout threshold with their external IDs.
+    """Get users at or above health risk threshold with their external IDs.
 
     Use this to identify at-risk responders and correlate with external
     systems (Rootly, PagerDuty, Slack) using their platform-specific IDs.
@@ -310,7 +310,7 @@ async def get_at_risk_users(
 
     Returns:
         - total_at_risk: count of users at or above threshold (och_score >= min_och_score)
-        - users: list of {user_name, och_score, risk_level, burnout_score,
+        - users: list of {user_name, och_score, risk_level, health_score,
                          incident_count, rootly_user_id, pagerduty_user_id,
                          slack_user_id, github_username}
 
@@ -358,7 +358,7 @@ async def get_at_risk_users(
                     "user_name": member.get("user_name", "Unknown"),
                     "och_score": och_score,
                     "risk_level": member.get("risk_level", "unknown"),
-                    "burnout_score": member.get("burnout_score", 0),
+                    "health_score": member.get("burnout_score", 0),  # Legacy field name, represents health score
                     "incident_count": member.get("incident_count", 0),
                     "rootly_user_id": member.get("rootly_user_id"),
                     "pagerduty_user_id": member.get("pagerduty_user_id"),
@@ -384,7 +384,7 @@ async def get_safe_responders(
     max_och_score: float = 30.0,
     limit: int = 10
 ) -> Dict[str, Any]:
-    """Get users with low burnout risk suitable for additional on-call.
+    """Get users with low health risk suitable for additional on-call.
 
     Use this to find replacement responders when removing at-risk users
     from schedules.
@@ -461,7 +461,7 @@ async def check_users_risk(
     rootly_user_ids: str,
     min_och_score: float = 50.0
 ) -> Dict[str, Any]:
-    """Check burnout risk for specific users by their Rootly user IDs.
+    """Check health risk for specific users by their Rootly user IDs.
 
     Use this after fetching a schedule from Rootly to check if any
     scheduled responders are at risk.
@@ -565,10 +565,9 @@ async def check_users_risk(
 def methodology_resource() -> str:
     """Provide a short methodology description."""
     return (
-        "On-Call Health measures overwork risk using a two-dimensional model inspired by the "
-        "Copenhagen Burnout Inventory. It combines objective workload signals (incidents, "
-        "communications, commits) with self-reported data to surface risk patterns without "
-        "providing medical diagnosis."
+        "On-Call Health measures overwork risk using a scientifically informed two-dimensional "
+        "model. It combines objective workload signals (incidents, communications, commits) "
+        "with self-reported data to surface risk patterns without providing medical diagnosis."
     )
 
 

--- a/packages/oncallhealth-mcp/src/oncallhealth_mcp/server.py
+++ b/packages/oncallhealth-mcp/src/oncallhealth_mcp/server.py
@@ -358,7 +358,7 @@ async def get_at_risk_users(
                     "user_name": member.get("user_name", "Unknown"),
                     "och_score": och_score,
                     "risk_level": member.get("risk_level", "unknown"),
-                    "health_score": member.get("burnout_score", 0),  # Legacy field name, represents health score
+                    "health_score": member.get("health_score", 0),
                     "incident_count": member.get("incident_count", 0),
                     "rootly_user_id": member.get("rootly_user_id"),
                     "pagerduty_user_id": member.get("pagerduty_user_id"),

--- a/packages/oncallhealth-mcp/src/oncallhealth_mcp/server.py
+++ b/packages/oncallhealth-mcp/src/oncallhealth_mcp/server.py
@@ -354,11 +354,16 @@ async def get_at_risk_users(
                     continue
 
                 # Build compact user object with external IDs
+                health_score = member.get("health_score")
+                if health_score is None:
+                    logger.warning(f"Member {member.get('user_name', 'Unknown')} missing health_score, defaulting to 0")
+                    health_score = 0
+
                 at_risk_users.append({
                     "user_name": member.get("user_name", "Unknown"),
                     "och_score": och_score,
                     "risk_level": member.get("risk_level", "unknown"),
-                    "health_score": member.get("health_score", 0),
+                    "health_score": health_score,
                     "incident_count": member.get("incident_count", 0),
                     "rootly_user_id": member.get("rootly_user_id"),
                     "pagerduty_user_id": member.get("pagerduty_user_id"),


### PR DESCRIPTION
## Summary

Removes all \"burnout\" terminology from user-facing content and renames API fields to use \"health\" terminology instead.

## Changes

### User-Facing Content (Non-Breaking)
- **Methodology page**: Removed Copenhagen Burnout Inventory references, renamed dimensions to \"Personal Wellbeing\" and \"Work-Related Wellbeing\"
- **README**: Removed CBI reference
- **UI comments**: Changed \"burnout\" → \"health risk\"
- **MCP server**: Updated tool descriptions and resource content

### API Changes (BREAKING)
- **Response field renames**:
  - `burnout_score` → `health_score` in member analysis
  - `average_burnout_score` → `average_health_score` in DailyTrendPoint
- **Backend**: Updated unified_burnout_analyzer.py and analyses.py
- **Frontend**: Updated variable names (burnoutScore → healthScore)
- **MCP**: Updated to read new field names

### Bug Fixes
- Fixed duplicate React key errors by using compound key (email + user_id)
- Fixed critical field naming mismatches found by Greptile

## Breaking Changes

⚠️ **API consumers will need to update**:
- Read `health_score` instead of `burnout_score` from member objects
- Read `average_health_score` instead of `average_burnout_score` from daily trend data

## Testing

Changes have been tested on staging environment.