### PR TITLE
Fix: Unify encryption key to resolve InvalidToken errors

### DIFF
--- a/backend/app/api/endpoints/github.py
+++ b/backend/app/api/endpoints/github.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # Simple encryption for tokens (in production, use proper key management)
 def get_encryption_key():
     """Get or create encryption key for tokens."""
-    key = settings.ENCRYPTION_KEY.encode()
+    key = settings.JWT_SECRET_KEY.encode()
     # Ensure key is 32 bytes for Fernet
     key = base64.urlsafe_b64encode(key[:32].ljust(32, b'\0'))
     return key

--- a/backend/app/api/endpoints/jira.py
+++ b/backend/app/api/endpoints/jira.py
@@ -47,7 +47,7 @@ REQUESTED_SCOPES = [
 # Encryption helpers
 # -------------------------------
 def get_encryption_key() -> bytes:
-    key = settings.ENCRYPTION_KEY.encode()
+    key = settings.JWT_SECRET_KEY.encode()
     # Ensure 32 bytes for Fernet
     return base64.urlsafe_b64encode(key[:32].ljust(32, b"\0"))
 

--- a/backend/app/api/endpoints/linear.py
+++ b/backend/app/api/endpoints/linear.py
@@ -44,7 +44,7 @@ REQUESTED_SCOPES = ["read"]
 # Encryption helpers (same as Jira)
 # -------------------------------
 def get_encryption_key() -> bytes:
-    key = settings.ENCRYPTION_KEY.encode()
+    key = settings.JWT_SECRET_KEY.encode()
     return base64.urlsafe_b64encode(key[:32].ljust(32, b"\0"))
 
 

--- a/backend/app/api/endpoints/llm.py
+++ b/backend/app/api/endpoints/llm.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # Token encryption utilities (same pattern as Slack/GitHub)
 def get_encryption_key():
     """Get or create encryption key for tokens."""
-    key = settings.ENCRYPTION_KEY.encode()
+    key = settings.JWT_SECRET_KEY.encode()
     # Ensure key is 32 bytes for Fernet
     key = base64.urlsafe_b64encode(key[:32].ljust(32, b'\0'))
     return key

--- a/backend/app/api/endpoints/slack.py
+++ b/backend/app/api/endpoints/slack.py
@@ -62,7 +62,7 @@ def get_active_workspace_mapping(db: Session, user: User) -> SlackWorkspaceMappi
 # Simple encryption for tokens (in production, use proper key management)
 def get_encryption_key():
     """Get or create encryption key for tokens."""
-    key = settings.ENCRYPTION_KEY.encode()
+    key = settings.JWT_SECRET_KEY.encode()
     # Ensure key is 32 bytes for Fernet
     key = base64.urlsafe_b64encode(key[:32].ljust(32, b'\0'))
     return key

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,29 +21,12 @@ class Settings:
             "For local development, use PostgreSQL (e.g., postgresql://user:password@localhost/dbname)"
         )
     
-    # JWT
+    # JWT - also used for integration token encryption
     JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY")
     if not JWT_SECRET_KEY:
-        if _IS_PRODUCTION:
-            raise ValueError("JWT_SECRET_KEY environment variable is required")
-        else:
-            raise ValueError(
-                "JWT_SECRET_KEY environment variable is required. "
-                "Generate with: openssl rand -hex 32"
-            )
+        raise ValueError("JWT_SECRET_KEY environment variable is required")
     JWT_ALGORITHM: str = "HS256"
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 days
-
-    # Token Encryption (separate from JWT signing for security)
-    ENCRYPTION_KEY: str = os.getenv("ENCRYPTION_KEY")
-    if not ENCRYPTION_KEY:
-        if _IS_PRODUCTION:
-            raise ValueError("ENCRYPTION_KEY environment variable is required")
-        else:
-            raise ValueError(
-                "ENCRYPTION_KEY environment variable is required. "
-                "Generate with: openssl rand -base64 32"
-            )
 
     # Frontend URL for survey links
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")

--- a/backend/app/services/integration_validator.py
+++ b/backend/app/services/integration_validator.py
@@ -35,7 +35,7 @@ def get_encryption_key() -> bytes:
     """
     from base64 import urlsafe_b64encode
 
-    key = settings.ENCRYPTION_KEY.encode()
+    key = settings.JWT_SECRET_KEY.encode()
     # Ensure key is 32 bytes for Fernet (consistent with other integration files)
     key = urlsafe_b64encode(key[:32].ljust(32, b'\0'))
 


### PR DESCRIPTION
## Problem

After the encryption key separation (commits a47b133b-9a0c87a7), integration syncs are failing with `InvalidToken` / `InvalidSignature` errors for GitHub, Jira, and Linear integrations.

**Root cause:**
- Tokens were encrypted with one key value
- After separation, trying to decrypt with a different key
- Result: `cryptography.fernet.InvalidToken` on every sync

## Solution

Revert to using a **single key** (`JWT_SECRET_KEY`) for both:
1. JWT authentication
2. Integration token encryption

## Changes

- Removed `ENCRYPTION_KEY` config requirement
- Updated all integration endpoints to use `JWT_SECRET_KEY`:
  - `backend/app/core/config.py` - removed ENCRYPTION_KEY
  - `backend/app/api/endpoints/github.py`
  - `backend/app/api/endpoints/jira.py`
  - `backend/app/api/endpoints/linear.py`
  - `backend/app/api/endpoints/llm.py`
  - `backend/app/api/endpoints/slack.py`
  - `backend/app/services/integration_validator.py`

## Impact

✅ **Simplifies configuration** - one key instead of two  
✅ **Fixes sync errors** - tokens decrypt successfully  
⚠️ **Railway requirement**: `JWT_SECRET_KEY` must be set to the value that was originally used to encrypt existing tokens

## Deployment Notes

1. Ensure Railway `JWT_SECRET_KEY` is set to the original encryption key value
2. If key was changed, users may need to reconnect integrations
3. No separate `ENCRYPTION_KEY` variable needed anymore