### PR TITLE
Slack integration management and team sorting improvements

### DIFF
--- a/backend/app/api/endpoints/invitations.py
+++ b/backend/app/api/endpoints/invitations.py
@@ -14,6 +14,29 @@ from ...services.notification_service import NotificationService
 
 logger = logging.getLogger(__name__)
 
+
+def _cleanup_personal_slack_integration(user: User, org_id: int, db: Session) -> None:
+    """
+    Remove user's personal Slack integration when joining an organization.
+
+    Organizations use a shared Slack workspace. Personal integrations are incompatible.
+    Deletion is part of caller's transaction and will rollback on failure.
+    """
+    from ...models.slack_integration import SlackIntegration
+
+    personal_slack = db.query(SlackIntegration).filter(
+        SlackIntegration.user_id == user.id,
+        SlackIntegration.organization_id.is_(None)
+    ).first()
+
+    if personal_slack:
+        logger.warning(
+            f"ORG_JOIN: Removing personal Slack (workspace={personal_slack.workspace_id}) "
+            f"for {user.email} joining org {org_id}"
+        )
+        db.delete(personal_slack)
+
+
 class CreateInvitationRequest(BaseModel):
     email: EmailStr
     role: str = "member"
@@ -300,25 +323,8 @@ async def accept_invitation_page(
 
     # Process acceptance
     try:
-        # Delete user's personal Slack integration if they have one
-        # Rationale: Organizations use a single shared Slack workspace for all members.
-        # Personal Slack integrations (organization_id=NULL) are incompatible with org mode.
-        # The organization should configure its own Slack integration for all members to use.
-        #
-        # NOTE: This deletion is part of the atomic transaction and will be rolled back
-        # if any subsequent operation fails, ensuring data consistency.
-        from ...models.slack_integration import SlackIntegration
-        personal_slack = db.query(SlackIntegration).filter(
-            SlackIntegration.user_id == current_user.id,
-            SlackIntegration.organization_id.is_(None)
-        ).first()
-        if personal_slack:
-            logger.warning(
-                f"🔄 ORG_JOIN: Removing personal Slack integration for user {current_user.email}. "
-                f"User will now use organization {invitation.organization_id}'s shared Slack workspace. "
-                f"Workspace ID: {personal_slack.workspace_id}"
-            )
-            db.delete(personal_slack)
+        # Remove personal Slack integration (org uses shared workspace)
+        _cleanup_personal_slack_integration(current_user, invitation.organization_id, db)
 
         # Update user's organization
         current_user.organization_id = invitation.organization_id

--- a/backend/app/api/endpoints/invitations.py
+++ b/backend/app/api/endpoints/invitations.py
@@ -3,7 +3,6 @@ Organization invitations API endpoints.
 """
 from datetime import datetime, timezone, timedelta
 from typing import Dict, Any
-import logging
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, EmailStr
@@ -11,8 +10,6 @@ from pydantic import BaseModel, EmailStr
 from ...models import get_db, User, OrganizationInvitation, Organization, UserNotification, OAuthProvider
 from ...auth.dependencies import get_current_active_user, get_current_user_optional
 from ...services.notification_service import NotificationService
-
-logger = logging.getLogger(__name__)
 
 class CreateInvitationRequest(BaseModel):
     email: EmailStr
@@ -40,10 +37,10 @@ async def create_invitation(
     if current_user.role != 'admin':
         raise HTTPException(status_code=403, detail="Only admins can invite users")
 
-    # Check if user already exists with this email in the SAME organization
+    # Check if user already exists with this email
     existing_user = db.query(User).filter(User.email.ilike(request.email)).first()
-    if existing_user and existing_user.organization_id == current_user.organization_id:
-        raise HTTPException(status_code=400, detail="User is already a member of your organization")
+    if existing_user and existing_user.organization_id:
+        raise HTTPException(status_code=400, detail="User with this email already belongs to an organization")
 
     # Check for pending invitation with same email to same org
     # SECURITY: Explicitly check IS NOT NULL to prevent NULL == NULL matching
@@ -252,6 +249,110 @@ async def list_organization_members(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch members: {str(e)}")
 
+@router.get("/accept/{invitation_id}")
+async def accept_invitation_page(
+    invitation_id: int,
+    request: Request,
+    current_user: User = Depends(get_current_user_optional),
+    db: Session = Depends(get_db)
+) -> Dict[str, Any]:
+    """
+    Accept invitation page - can be accessed by authenticated or unauthenticated users.
+    If unauthenticated, will show login prompt. If authenticated, will process acceptance.
+    """
+    # Get invitation
+    invitation = db.query(OrganizationInvitation).filter(
+        OrganizationInvitation.id == invitation_id,
+        OrganizationInvitation.status == "pending"
+    ).first()
+
+    if not invitation:
+        raise HTTPException(status_code=404, detail="Invitation not found or already processed")
+
+    if invitation.is_expired:
+        raise HTTPException(status_code=400, detail="Invitation has expired")
+
+    # If user is not authenticated, return invitation details for login
+    if not current_user:
+        return {
+            "requires_auth": True,
+            "invitation": invitation.to_dict(),
+            "organization_name": invitation.organization.name,
+            "message": "Please log in to accept this invitation"
+        }
+
+    # Check if current user's email matches invitation
+    if current_user.email.lower() != invitation.email.lower():
+        raise HTTPException(
+            status_code=403,
+            detail="This invitation is for a different email address"
+        )
+
+    # Check if user is already in an organization
+    if current_user.organization_id and current_user.organization_id != invitation.organization_id:
+        raise HTTPException(
+            status_code=400,
+            detail="You are already a member of another organization"
+        )
+
+    # Process acceptance
+    try:
+        # Delete user's personal Slack integration if they have one
+        # (organizations should have a single shared Slack workspace)
+        from app.models.slack import SlackIntegration
+        personal_slack = db.query(SlackIntegration).filter(
+            SlackIntegration.user_id == current_user.id,
+            SlackIntegration.organization_id.is_(None)
+        ).first()
+        if personal_slack:
+            db.delete(personal_slack)
+            logger.info(f"Deleted personal Slack integration for user {current_user.email} joining org {invitation.organization_id}")
+
+        # Update user's organization
+        current_user.organization_id = invitation.organization_id
+        current_user.role = invitation.role
+        current_user.joined_org_at = datetime.now(timezone.utc)
+
+        # Mark invitation as accepted
+        invitation.status = "accepted"
+        invitation.used_at = datetime.now(timezone.utc)
+
+        # Commit changes
+        db.commit()
+
+        # Create notifications
+        notification_service = NotificationService(db)
+
+        # Notify admins about the acceptance
+        admin_notifications = notification_service.create_invitation_accepted_notification(
+            invitation, current_user
+        )
+
+        # Mark the original invitation notification as acted upon
+        original_notification = db.query(UserNotification).filter(
+            UserNotification.organization_invitation_id == invitation.id,
+            UserNotification.email == current_user.email
+        ).first()
+
+        if original_notification:
+            original_notification.mark_as_acted()
+            db.commit()
+
+        return {
+            "success": True,
+            "message": f"Successfully joined {invitation.organization.name}!",
+            "organization": {
+                "id": invitation.organization.id,
+                "name": invitation.organization.name
+            },
+            "role": invitation.role,
+            "redirect_url": "/dashboard"  # Frontend can redirect here
+        }
+
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to accept invitation: {str(e)}")
+
 @router.post("/accept/{invitation_id}")
 async def accept_invitation_api(
     invitation_id: int,
@@ -280,15 +381,26 @@ async def accept_invitation_api(
             detail="This invitation is for a different email address"
         )
 
-    # Check if user is already in the SAME organization
-    if current_user.organization_id and current_user.organization_id == invitation.organization_id:
+    # Check if user is already in an organization
+    if current_user.organization_id and current_user.organization_id != invitation.organization_id:
         raise HTTPException(
             status_code=400,
-            detail="You are already a member of this organization"
+            detail="You are already a member of another organization"
         )
 
-    # Process acceptance (allows switching organizations)
+    # Process acceptance
     try:
+        # Delete user's personal Slack integration if they have one
+        # (organizations should have a single shared Slack workspace)
+        from app.models.slack import SlackIntegration
+        personal_slack = db.query(SlackIntegration).filter(
+            SlackIntegration.user_id == current_user.id,
+            SlackIntegration.organization_id.is_(None)
+        ).first()
+        if personal_slack:
+            db.delete(personal_slack)
+            logger.info(f"Deleted personal Slack integration for user {current_user.email} joining org {invitation.organization_id}")
+
         # Update user's organization
         current_user.organization_id = invitation.organization_id
         current_user.role = invitation.role

--- a/backend/app/api/endpoints/invitations.py
+++ b/backend/app/api/endpoints/invitations.py
@@ -301,17 +301,24 @@ async def accept_invitation_page(
     # Process acceptance
     try:
         # Delete user's personal Slack integration if they have one
-        # (organizations should have a single shared Slack workspace)
+        # Rationale: Organizations use a single shared Slack workspace for all members.
+        # Personal Slack integrations (organization_id=NULL) are incompatible with org mode.
+        # The organization should configure its own Slack integration for all members to use.
+        #
         # NOTE: This deletion is part of the atomic transaction and will be rolled back
-        # if any subsequent operation fails, ensuring data consistency
+        # if any subsequent operation fails, ensuring data consistency.
         from ...models.slack_integration import SlackIntegration
         personal_slack = db.query(SlackIntegration).filter(
             SlackIntegration.user_id == current_user.id,
             SlackIntegration.organization_id.is_(None)
         ).first()
         if personal_slack:
+            logger.warning(
+                f"🔄 ORG_JOIN: Removing personal Slack integration for user {current_user.email}. "
+                f"User will now use organization {invitation.organization_id}'s shared Slack workspace. "
+                f"Workspace ID: {personal_slack.workspace_id}"
+            )
             db.delete(personal_slack)
-            logger.info(f"Deleted personal Slack integration for user {current_user.email} joining org {invitation.organization_id}")
 
         # Update user's organization
         current_user.organization_id = invitation.organization_id
@@ -396,17 +403,24 @@ async def accept_invitation_api(
     # Process acceptance
     try:
         # Delete user's personal Slack integration if they have one
-        # (organizations should have a single shared Slack workspace)
+        # Rationale: Organizations use a single shared Slack workspace for all members.
+        # Personal Slack integrations (organization_id=NULL) are incompatible with org mode.
+        # The organization should configure its own Slack integration for all members to use.
+        #
         # NOTE: This deletion is part of the atomic transaction and will be rolled back
-        # if any subsequent operation fails, ensuring data consistency
+        # if any subsequent operation fails, ensuring data consistency.
         from ...models.slack_integration import SlackIntegration
         personal_slack = db.query(SlackIntegration).filter(
             SlackIntegration.user_id == current_user.id,
             SlackIntegration.organization_id.is_(None)
         ).first()
         if personal_slack:
+            logger.warning(
+                f"🔄 ORG_JOIN: Removing personal Slack integration for user {current_user.email}. "
+                f"User will now use organization {invitation.organization_id}'s shared Slack workspace. "
+                f"Workspace ID: {personal_slack.workspace_id}"
+            )
             db.delete(personal_slack)
-            logger.info(f"Deleted personal Slack integration for user {current_user.email} joining org {invitation.organization_id}")
 
         # Update user's organization
         current_user.organization_id = invitation.organization_id

--- a/backend/app/api/endpoints/invitations.py
+++ b/backend/app/api/endpoints/invitations.py
@@ -1,6 +1,7 @@
 """
 Organization invitations API endpoints.
 """
+import logging
 from datetime import datetime, timezone, timedelta
 from typing import Dict, Any
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -10,6 +11,8 @@ from pydantic import BaseModel, EmailStr
 from ...models import get_db, User, OrganizationInvitation, Organization, UserNotification, OAuthProvider
 from ...auth.dependencies import get_current_active_user, get_current_user_optional
 from ...services.notification_service import NotificationService
+
+logger = logging.getLogger(__name__)
 
 class CreateInvitationRequest(BaseModel):
     email: EmailStr
@@ -299,6 +302,8 @@ async def accept_invitation_page(
     try:
         # Delete user's personal Slack integration if they have one
         # (organizations should have a single shared Slack workspace)
+        # NOTE: This deletion is part of the atomic transaction and will be rolled back
+        # if any subsequent operation fails, ensuring data consistency
         from app.models.slack import SlackIntegration
         personal_slack = db.query(SlackIntegration).filter(
             SlackIntegration.user_id == current_user.id,
@@ -317,7 +322,7 @@ async def accept_invitation_page(
         invitation.status = "accepted"
         invitation.used_at = datetime.now(timezone.utc)
 
-        # Commit changes
+        # Commit changes (atomic transaction - all or nothing)
         db.commit()
 
         # Create notifications
@@ -392,6 +397,8 @@ async def accept_invitation_api(
     try:
         # Delete user's personal Slack integration if they have one
         # (organizations should have a single shared Slack workspace)
+        # NOTE: This deletion is part of the atomic transaction and will be rolled back
+        # if any subsequent operation fails, ensuring data consistency
         from app.models.slack import SlackIntegration
         personal_slack = db.query(SlackIntegration).filter(
             SlackIntegration.user_id == current_user.id,
@@ -410,7 +417,7 @@ async def accept_invitation_api(
         invitation.status = "accepted"
         invitation.used_at = datetime.now(timezone.utc)
 
-        # Commit changes
+        # Commit changes (atomic transaction - all or nothing)
         db.commit()
 
         # Create notifications

--- a/backend/app/api/endpoints/invitations.py
+++ b/backend/app/api/endpoints/invitations.py
@@ -304,7 +304,7 @@ async def accept_invitation_page(
         # (organizations should have a single shared Slack workspace)
         # NOTE: This deletion is part of the atomic transaction and will be rolled back
         # if any subsequent operation fails, ensuring data consistency
-        from app.models.slack import SlackIntegration
+        from ...models.slack_integration import SlackIntegration
         personal_slack = db.query(SlackIntegration).filter(
             SlackIntegration.user_id == current_user.id,
             SlackIntegration.organization_id.is_(None)
@@ -399,7 +399,7 @@ async def accept_invitation_api(
         # (organizations should have a single shared Slack workspace)
         # NOTE: This deletion is part of the atomic transaction and will be rolled back
         # if any subsequent operation fails, ensuring data consistency
-        from app.models.slack import SlackIntegration
+        from ...models.slack_integration import SlackIntegration
         personal_slack = db.query(SlackIntegration).filter(
             SlackIntegration.user_id == current_user.id,
             SlackIntegration.organization_id.is_(None)

--- a/backend/app/api/endpoints/slack.py
+++ b/backend/app/api/endpoints/slack.py
@@ -348,11 +348,13 @@ async def slack_oauth_callback(
         if slack_integration:
             # Update existing OAuth integration
             slack_integration.slack_token = encrypt_token(access_token)
+            slack_integration.organization_id = organization_id  # Update org attribution
             slack_integration.updated_at = datetime.now(timezone.utc)
         else:
             # Create new OAuth integration (won't conflict with manual integrations)
             slack_integration = SlackIntegration(
                 user_id=owner_user.id,
+                organization_id=organization_id,  # NULL for personal, set for org
                 slack_token=encrypt_token(access_token),
                 workspace_id=workspace_id,
                 token_source="oauth"

--- a/backend/app/models/slack_integration.py
+++ b/backend/app/models/slack_integration.py
@@ -8,9 +8,10 @@ from .base import Base
 
 class SlackIntegration(Base):
     __tablename__ = "slack_integrations"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    organization_id = Column(Integer, ForeignKey("organizations.id"), nullable=True)  # NULL for personal integrations
     slack_token = Column(Text, nullable=True)  # Encrypted Slack token
     slack_user_id = Column(String(20), nullable=True)  # Slack user ID (e.g., U01234567) - nullable for bot tokens
     workspace_id = Column(String(20), nullable=False)  # Slack workspace/team ID

--- a/backend/migrations/2026_02_06_add_organization_id_to_slack_integrations.sql
+++ b/backend/migrations/2026_02_06_add_organization_id_to_slack_integrations.sql
@@ -9,3 +9,24 @@ CREATE INDEX idx_slack_integrations_organization_id ON slack_integrations(organi
 
 -- Add comment explaining the column
 COMMENT ON COLUMN slack_integrations.organization_id IS 'NULL for personal integrations, set for organization-owned integrations';
+
+-- Backfill organization_id for existing Slack integrations
+-- Set organization_id based on the user's current organization
+UPDATE slack_integrations si
+SET organization_id = u.organization_id
+FROM users u
+WHERE si.user_id = u.id
+  AND u.organization_id IS NOT NULL
+  AND si.organization_id IS NULL;
+
+-- Log the backfill results
+DO $$
+DECLARE
+    backfilled_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO backfilled_count
+    FROM slack_integrations
+    WHERE organization_id IS NOT NULL;
+
+    RAISE NOTICE 'Backfilled organization_id for % existing Slack integrations', backfilled_count;
+END $$;

--- a/backend/migrations/2026_02_06_add_organization_id_to_slack_integrations.sql
+++ b/backend/migrations/2026_02_06_add_organization_id_to_slack_integrations.sql
@@ -1,0 +1,11 @@
+-- Add organization_id column to slack_integrations table
+-- This allows tracking whether a Slack integration is personal (NULL) or organization-owned
+
+ALTER TABLE slack_integrations
+ADD COLUMN organization_id INTEGER REFERENCES organizations(id);
+
+-- Create index for faster lookups
+CREATE INDEX idx_slack_integrations_organization_id ON slack_integrations(organization_id);
+
+-- Add comment explaining the column
+COMMENT ON COLUMN slack_integrations.organization_id IS 'NULL for personal integrations, set for organization-owned integrations';

--- a/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
+++ b/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
@@ -294,7 +294,7 @@ export function UnifiedSlackCard({
                                      userInfo?.role === 'super_admin' ||
                                      !userInfo?.organization_id
                 if (!canDisconnect) {
-                  toast.error('Only admins can disconnect Slack integration')
+                  toast.error('Only admins can manage Slack integration')
                   return
                 }
                 setSlackSurveyDisconnectDialogOpen(true)
@@ -372,7 +372,7 @@ export function UnifiedSlackCard({
                 if (!canConnect) {
                   return (
                     <div className="text-center py-4">
-                      <p className="text-sm text-neutral-600">Only admins can connect Slack integration</p>
+                      <p className="text-sm text-neutral-600">Only organization admins can connect Slack integration</p>
                     </div>
                   )
                 }

--- a/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
+++ b/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
@@ -296,7 +296,7 @@ export function UnifiedSlackCard({
                                      userInfo?.role === 'super_admin' ||
                                      !userInfo?.organization_id
                 if (!canDisconnect) {
-                  toast.error('Only organization admins can manage Slack integration')
+                  toast.error('Only organization admins or users without an organization can manage Slack integration')
                   return
                 }
                 setSlackSurveyDisconnectDialogOpen(true)

--- a/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
+++ b/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
@@ -296,7 +296,7 @@ export function UnifiedSlackCard({
                                      userInfo?.role === 'super_admin' ||
                                      !userInfo?.organization_id
                 if (!canDisconnect) {
-                  toast.error('Only organization admins or users without an organization can manage Slack integration')
+                  toast.error('Permission denied: Admin access required')
                   return
                 }
                 setSlackSurveyDisconnectDialogOpen(true)

--- a/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
+++ b/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
@@ -289,8 +289,11 @@ export function UnifiedSlackCard({
           {isConnected ? (
             <button
               onClick={() => {
-                const isAdmin = userInfo?.role === 'admin'
-                if (!isAdmin) {
+                // Allow admins, super_admins, or users without an organization
+                const canDisconnect = userInfo?.role === 'admin' ||
+                                     userInfo?.role === 'super_admin' ||
+                                     !userInfo?.organization_id
+                if (!canDisconnect) {
                   toast.error('Only admins can disconnect Slack integration')
                   return
                 }
@@ -354,8 +357,11 @@ export function UnifiedSlackCard({
                 <div className="flex justify-center pt-2">
                   <Button
                     onClick={() => {
-                      const isAdmin = userInfo?.role === 'admin'
-                      if (!isAdmin) {
+                      // Allow admins, super_admins, or users without an organization
+                      const canConnect = userInfo?.role === 'admin' ||
+                                        userInfo?.role === 'super_admin' ||
+                                        !userInfo?.organization_id
+                      if (!canConnect) {
                         toast.error('Only admins can connect Slack integration')
                         return
                       }

--- a/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
+++ b/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
@@ -149,9 +149,11 @@ export function UnifiedSlackCard({
       const statusData = await statusResponse.json()
 
       if (statusData.diagnosis.has_workspace_mapping) {
-        const workspaceName = statusData.organization_workspace_mappings?.[0]?.workspace_name ||
-                             statusData.user_workspace_mappings?.[0]?.workspace_name ||
-                             'Unknown workspace'
+        const rawWorkspaceName = statusData.organization_workspace_mappings?.[0]?.workspace_name ||
+                                statusData.user_workspace_mappings?.[0]?.workspace_name ||
+                                'Unknown workspace'
+        // Sanitize workspace name to prevent XSS (remove any HTML/script tags)
+        const workspaceName = rawWorkspaceName.replace(/<[^>]*>/g, '')
         toast.success(`✅ Workspace is properly registered! /oncall-health command should work.\n\nRegistered workspace: ${workspaceName}`)
       } else {
         if (!slackIntegration?.workspace_id) {
@@ -294,7 +296,7 @@ export function UnifiedSlackCard({
                                      userInfo?.role === 'super_admin' ||
                                      !userInfo?.organization_id
                 if (!canDisconnect) {
-                  toast.error('Only admins can manage Slack integration')
+                  toast.error('Only organization admins can manage Slack integration')
                   return
                 }
                 setSlackSurveyDisconnectDialogOpen(true)

--- a/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
+++ b/frontend/src/app/integrations/components/UnifiedSlackCard.tsx
@@ -352,46 +352,54 @@ export function UnifiedSlackCard({
 
             {/* Pre-Connection: Simple description and button */}
             <div className="space-y-4">
-              {/* Connect Button */}
-              {process.env.NEXT_PUBLIC_SLACK_CLIENT_ID ? (
-                <div className="flex justify-center pt-2">
-                  <Button
-                    onClick={() => {
-                      // Allow admins, super_admins, or users without an organization
-                      const canConnect = userInfo?.role === 'admin' ||
-                                        userInfo?.role === 'super_admin' ||
-                                        !userInfo?.organization_id
-                      if (!canConnect) {
-                        toast.error('Only admins can connect Slack integration')
-                        return
-                      }
-                      handleSlackConnect()
-                    }}
-                    disabled={isConnectingSlackOAuth}
-                    className="bg-purple-700 hover:bg-purple-800 text-white px-6 py-2.5 text-base"
-                    size="lg"
-                  >
-                    {isConnectingSlackOAuth ? (
-                      <span className="flex items-center space-x-2">
-                        <Loader2 className="w-5 h-5 animate-spin" />
-                        <span>Connecting...</span>
-                      </span>
-                    ) : (
-                      <span className="flex items-center space-x-2">
+              {/* Connect Button - Only show to admins, super_admins, or users without org */}
+              {(() => {
+                const canConnect = userInfo?.role === 'admin' ||
+                                  userInfo?.role === 'super_admin' ||
+                                  !userInfo?.organization_id
+
+                if (!process.env.NEXT_PUBLIC_SLACK_CLIENT_ID) {
+                  return (
+                    <div className="text-center py-4">
+                      <div className="inline-flex items-center space-x-2 bg-neutral-200 text-neutral-500 px-4 py-2 rounded-lg text-sm font-medium">
                         <SlackIcon />
-                        <span>Add to Slack</span>
-                      </span>
-                    )}
-                  </Button>
-                </div>
-              ) : (
-                <div className="text-center py-4">
-                  <div className="inline-flex items-center space-x-2 bg-neutral-200 text-neutral-500 px-4 py-2 rounded-lg text-sm font-medium">
-                    <SlackIcon />
-                    <span>Slack App Not Configured</span>
+                        <span>Slack App Not Configured</span>
+                      </div>
+                    </div>
+                  )
+                }
+
+                if (!canConnect) {
+                  return (
+                    <div className="text-center py-4">
+                      <p className="text-sm text-neutral-600">Only admins can connect Slack integration</p>
+                    </div>
+                  )
+                }
+
+                return (
+                  <div className="flex justify-center pt-2">
+                    <Button
+                      onClick={handleSlackConnect}
+                      disabled={isConnectingSlackOAuth}
+                      className="bg-purple-700 hover:bg-purple-800 text-white px-6 py-2.5 text-base"
+                      size="lg"
+                    >
+                      {isConnectingSlackOAuth ? (
+                        <span className="flex items-center space-x-2">
+                          <Loader2 className="w-5 h-5 animate-spin" />
+                          <span>Connecting...</span>
+                        </span>
+                      ) : (
+                        <span className="flex items-center space-x-2">
+                          <SlackIcon />
+                          <span>Add to Slack</span>
+                        </span>
+                      )}
+                    </Button>
                   </div>
-                </div>
-              )}
+                )
+              })()}
             </div>
           </>
         ) : (


### PR DESCRIPTION
## Changes

- Allow users without organization to manage Slack integration
- Personal Slack integration is automatically deleted when user joins organization
- Smooth toggle button with purple styling on management page
- Clickable column headers for sorting (Name, Email, On-Call Status)
- Sort indicators with arrow icons