### PR TITLE
feat: name-based GitHub matching fallback with Redis caching

### DIFF
--- a/backend/app/services/enhanced_github_matcher.py
+++ b/backend/app/services/enhanced_github_matcher.py
@@ -9,9 +9,14 @@ from difflib import SequenceMatcher
 import aiohttp
 from datetime import datetime, timedelta, timezone
 
+from .github_org_cache import (
+    get_cached_org_members, set_cached_org_members,
+    get_cached_org_profiles, set_cached_org_profiles,
+)
+
 logger = logging.getLogger(__name__)
 
-# Global cache to persist across matcher instances
+# In-memory fallback (used within a single process lifetime)
 _GLOBAL_ORG_CACHE = {}
 _GLOBAL_MEMBER_PROFILES_CACHE = {}
 
@@ -142,13 +147,24 @@ class EnhancedGitHubMatcher:
                 
                 # Try different matching strategies against the known member list
                 result = await self._match_name_against_members(full_name_clean, all_members, fallback_email)
-                
+
                 if result:
                     return result
-                    
+
         except Exception as e:
             logger.error(f"Error in optimized name matching: {e}")
-        
+
+        # FALLBACK: Search GitHub by profile name using search API
+        try:
+            name_parts = self._extract_name_parts_from_full_name(full_name_clean)
+            if name_parts:
+                search_result = await self._search_github_by_name(name_parts, full_name_clean, fallback_email)
+                if search_result:
+                    logger.info(f"✅ GitHub search API matched '{full_name_clean}' -> {search_result}")
+                    return search_result
+        except Exception as e:
+            logger.warning(f"GitHub search API fallback failed for '{full_name_clean}': {e}")
+
         logger.warning(f"❌ No GitHub match found for name: '{full_name_clean}'")
         return None
     
@@ -163,33 +179,39 @@ class EnhancedGitHubMatcher:
 
             for org in self.organizations:
                 try:
+                    # 1) Check Redis cache for profiles (survives deploys)
+                    redis_profiles = get_cached_org_profiles(org)
+                    if redis_profiles:
+                        all_members.extend(redis_profiles)
+                        # Also populate in-memory caches for this process
+                        _GLOBAL_MEMBER_PROFILES_CACHE[f"{org}_profiles"] = redis_profiles
+                        if org not in self._org_members_cache:
+                            self._org_members_cache[org] = set(p['username'] for p in redis_profiles)
+                        continue
 
-                    # Get org members list
-                    if org not in self._org_members_cache:
-                        members = await self._get_org_members(org, session)
-                        self._org_members_cache[org] = members
-
-                    # Check if we have cached profiles already (persist across sync runs)
+                    # 2) Check in-memory cache (same process)
                     cache_key = f"{org}_profiles"
                     if cache_key in _GLOBAL_MEMBER_PROFILES_CACHE:
                         cached_profiles = _GLOBAL_MEMBER_PROFILES_CACHE[cache_key]
                         all_members.extend(cached_profiles)
                         continue
 
-                    # Batch fetch profiles concurrently (much faster than sequential)
+                    # 3) Cache miss — fetch from GitHub API
+                    if org not in self._org_members_cache:
+                        members = await self._get_org_members(org, session)
+                        self._org_members_cache[org] = members
+                        set_cached_org_members(org, list(members))
+
                     org_profiles = []
                     usernames = list(self._org_members_cache[org])
 
-                    # Process in batches of 10 to avoid overwhelming the API
                     batch_size = 10
                     for i in range(0, len(usernames), batch_size):
                         batch = usernames[i:i + batch_size]
 
-                        # Fetch all profiles in this batch concurrently
                         tasks = [self._get_github_user_profile(username, session) for username in batch]
                         profiles = await asyncio.gather(*tasks, return_exceptions=True)
 
-                        # Process results
                         for username, profile in zip(batch, profiles):
                             if isinstance(profile, Exception):
                                 logger.debug(f"Error fetching profile for {username}: {profile}")
@@ -203,12 +225,12 @@ class EnhancedGitHubMatcher:
                                     'organization': org
                                 })
 
-                        # Small delay between batches to respect rate limits
                         if i + batch_size < len(usernames):
                             await asyncio.sleep(0.5)
 
-                    # Cache profiles globally for this org
+                    # Store in both Redis (survives deploys) and in-memory (fast)
                     _GLOBAL_MEMBER_PROFILES_CACHE[cache_key] = org_profiles
+                    set_cached_org_profiles(org, org_profiles)
                     all_members.extend(org_profiles)
 
 

--- a/backend/app/services/github_collector.py
+++ b/backend/app/services/github_collector.py
@@ -61,7 +61,20 @@ class GitHubCollector:
                 if manual_username:
                     return manual_username
 
-            # No fallback matching during analysis - use "Sync Members" on integrations page
+            # FALLBACK: Try name-based matching against org members
+            if full_name and token:
+                try:
+                    from .enhanced_github_matcher import EnhancedGitHubMatcher
+                    matcher = EnhancedGitHubMatcher(token, self.organizations)
+                    name_match = await matcher.match_name_to_github(full_name, fallback_email=email)
+                    if name_match:
+                        logger.info(f"✅ [NAME_FALLBACK] Matched {email} -> {name_match} via name '{full_name}'")
+                        return name_match
+                    else:
+                        logger.debug(f"[NAME_FALLBACK] No match found for name '{full_name}' ({email})")
+                except Exception as e:
+                    logger.warning(f"⚠️ [NAME_FALLBACK] Error during name matching for '{full_name}': {e}")
+
             return None
 
         except Exception as e:
@@ -631,8 +644,27 @@ class GitHubCollector:
         if github_token:
             result = await self._fetch_real_github_data(github_username, user_email, start_date, end_date, github_token, timezone)
             if not result:
-                logger.error(f"Failed to fetch GitHub data for {github_username}")
-                return None
+                logger.warning(f"Failed to fetch GitHub activity for {github_username}, returning username-only result")
+                # Return minimal result so the username match is preserved in analysis results
+                days_analyzed = (end_date - start_date).days
+                return {
+                    'username': github_username,
+                    'email': user_email,
+                    'analysis_period': {'start': start_date.isoformat(), 'end': end_date.isoformat(), 'days': days_analyzed},
+                    'metrics': {
+                        'total_commits': 0, 'total_pull_requests': 0, 'total_reviews': 0,
+                        'commits_per_week': 0, 'prs_per_week': 0,
+                        'after_hours_commit_percentage': 0, 'weekend_commit_percentage': 0,
+                        'repositories_touched': 0, 'avg_pr_size': 0, 'clustered_commits': 0,
+                    },
+                    'burnout_indicators': {'excessive_commits': False, 'late_night_activity': False, 'weekend_work': False, 'large_prs': False},
+                    'activity_data': {
+                        'commits_count': 0, 'pull_requests_count': 0, 'reviews_count': 0,
+                        'after_hours_commits': 0, 'weekend_commits': 0, 'avg_pr_size': 0,
+                        'burnout_indicators': {'excessive_commits': False, 'late_night_activity': False, 'weekend_work': False, 'large_prs': False},
+                    },
+                    'commits': [],
+                }
             return result
         else:
             logger.warning(f"No GitHub token provided, generating mock data for {github_username}")
@@ -743,7 +775,7 @@ class GitHubCollector:
         self.last_request_time = time.time()
 
 
-async def collect_team_github_data(team_emails: List[str], days: int = 30, github_token: str = None, user_id: Optional[int] = None, timezone: str = 'UTC') -> Dict[str, Dict]:
+async def collect_team_github_data(team_emails: List[str], days: int = 30, github_token: str = None, user_id: Optional[int] = None, timezone: str = 'UTC', email_to_name: Optional[Dict[str, str]] = None) -> Dict[str, Dict]:
     """
     Collect GitHub data for all team members.
 
@@ -753,6 +785,7 @@ async def collect_team_github_data(team_emails: List[str], days: int = 30, githu
         github_token: GitHub API token for real data collection
         user_id: User ID for checking manual mappings
         timezone: User's timezone for business hours calculation (default: 'UTC')
+        email_to_name: Optional mapping of email -> full name for name-based matching
 
     Returns:
         Dict mapping email -> github_activity_data
@@ -760,13 +793,25 @@ async def collect_team_github_data(team_emails: List[str], days: int = 30, githu
     collector = GitHubCollector()
     github_data = {}
 
-    for email in team_emails:
+    # GitHub Search API limit: 30 requests/minute.
+    # Each user needs ~3 search calls (commits count, PRs count, daily commits).
+    # Process in waves of 8 users then pause to stay under the limit.
+    WAVE_SIZE = 8
+    WAVE_PAUSE_SECONDS = 65  # just over 1 minute to reset the search window
+
+    for i, email in enumerate(team_emails):
         try:
-            user_data = await collector.collect_github_data_for_user(email, days, github_token, user_id, timezone=timezone)
+            # Pause between waves to respect search API rate limit
+            if i > 0 and i % WAVE_SIZE == 0 and len(github_data) >= WAVE_SIZE:
+                logger.info(f"⏳ Search API throttle: pausing {WAVE_PAUSE_SECONDS}s after {i} emails ({len(github_data)} matched so far)")
+                await asyncio.sleep(WAVE_PAUSE_SECONDS)
+
+            full_name = email_to_name.get(email) if email_to_name else None
+            user_data = await collector.collect_github_data_for_user(email, days, github_token, user_id, full_name=full_name, timezone=timezone)
             if user_data:
                 github_data[email] = user_data
         except Exception as e:
             logger.error(f"Failed to collect GitHub data for {email}: {e}")
-    
+
     logger.info(f"Collected GitHub data for {len(github_data)} users out of {len(team_emails)}")
     return github_data

--- a/backend/app/services/github_mapping_service.py
+++ b/backend/app/services/github_mapping_service.py
@@ -80,11 +80,12 @@ class GitHubMappingService:
                 logger.debug(f"🔄 Cache STALE: {email} mapping is {self._get_mapping_age_days(cached_mapping)} days old")
                 
             elif cached_mapping and not cached_mapping.mapping_successful:
-                # Failed mapping: retry if enough time passed
-                if self._should_retry_failed_mapping(cached_mapping):
+                # Failed mapping: retry if we have a name to try (new strategy) or enough time passed
+                has_name = email_to_name and email_to_name.get(email)
+                if has_name or self._should_retry_failed_mapping(cached_mapping):
                     cache_stats["retries"] += 1
                     emails_needing_mapping.append(email)
-                    logger.debug(f"🔄 RETRY: {email} failed mapping ready for retry")
+                    logger.debug(f"🔄 RETRY: {email} failed mapping ready for retry (name_available={bool(has_name)})")
                 else:
                     logger.debug(f"⏳ SKIP: {email} failed mapping too recent to retry")
                     
@@ -228,7 +229,9 @@ class GitHubMappingService:
             result = await collect_team_github_data(
                 team_emails=emails,
                 days=days,
-                github_token=github_token
+                github_token=github_token,
+                user_id=user_id,
+                email_to_name=email_to_name
             )
             if result is None:
                 logger.warning("collect_team_github_data returned None - possible API or auth issue")

--- a/backend/app/services/github_org_cache.py
+++ b/backend/app/services/github_org_cache.py
@@ -1,0 +1,135 @@
+"""
+Redis-backed cache for GitHub organization members and profiles.
+
+Avoids re-fetching ~60 member profiles on every analysis/deploy,
+saving GitHub API rate limit for actual activity data.
+"""
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Set
+
+import redis
+
+logger = logging.getLogger(__name__)
+
+# Org membership is stable — cache for 24 hours
+ORG_MEMBERS_TTL_SECONDS = 86400
+ORG_PROFILES_TTL_SECONDS = 86400
+
+_fallback_cache: Dict[str, Dict] = {}
+_fallback_lock = threading.RLock()
+
+
+def _get_redis_client() -> Optional[redis.Redis]:
+    """Get Redis client."""
+    try:
+        redis_url = os.getenv("REDIS_URL")
+        if not redis_url:
+            return None
+        client = redis.from_url(redis_url, decode_responses=True)
+        client.ping()
+        return client
+    except Exception as e:
+        logger.warning(f"Redis unavailable for github org cache: {e}")
+        return None
+
+
+def _build_cache_key(prefix: str, org: str) -> str:
+    return f"github_org:{prefix}:{org}"
+
+
+def get_cached_org_members(org: str) -> Optional[List[str]]:
+    """Get cached org member logins."""
+    cache_key = _build_cache_key("members", org)
+
+    client = _get_redis_client()
+    if client:
+        try:
+            cached_data = client.get(cache_key)
+            if cached_data:
+                data = json.loads(cached_data)
+                logger.debug(f"Redis HIT: {len(data['members'])} members for {org}")
+                return data["members"]
+        except Exception as e:
+            logger.warning(f"Redis read error for org members: {e}")
+
+    with _fallback_lock:
+        if cache_key in _fallback_cache:
+            cached = _fallback_cache[cache_key]
+            age = (datetime.now(timezone.utc) - cached["timestamp"]).total_seconds()
+            if age < ORG_MEMBERS_TTL_SECONDS:
+                return cached["members"]
+            del _fallback_cache[cache_key]
+
+    return None
+
+
+def set_cached_org_members(org: str, members: List[str]) -> None:
+    """Cache org member logins."""
+    cache_key = _build_cache_key("members", org)
+    payload = {
+        "members": members,
+        "cached_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    client = _get_redis_client()
+    if client:
+        try:
+            client.setex(cache_key, ORG_MEMBERS_TTL_SECONDS, json.dumps(payload))
+            logger.info(f"Cached {len(members)} org members for {org} (TTL={ORG_MEMBERS_TTL_SECONDS}s)")
+            return
+        except Exception as e:
+            logger.warning(f"Redis write error for org members: {e}")
+
+    with _fallback_lock:
+        _fallback_cache[cache_key] = {"members": members, "timestamp": datetime.now(timezone.utc)}
+
+
+def get_cached_org_profiles(org: str) -> Optional[List[Dict]]:
+    """Get cached org member profiles (login + display name)."""
+    cache_key = _build_cache_key("profiles", org)
+
+    client = _get_redis_client()
+    if client:
+        try:
+            cached_data = client.get(cache_key)
+            if cached_data:
+                data = json.loads(cached_data)
+                logger.debug(f"Redis HIT: {len(data['profiles'])} profiles for {org}")
+                return data["profiles"]
+        except Exception as e:
+            logger.warning(f"Redis read error for org profiles: {e}")
+
+    with _fallback_lock:
+        if cache_key in _fallback_cache:
+            cached = _fallback_cache[cache_key]
+            age = (datetime.now(timezone.utc) - cached["timestamp"]).total_seconds()
+            if age < ORG_PROFILES_TTL_SECONDS:
+                return cached["profiles"]
+            del _fallback_cache[cache_key]
+
+    return None
+
+
+def set_cached_org_profiles(org: str, profiles: List[Dict]) -> None:
+    """Cache org member profiles."""
+    cache_key = _build_cache_key("profiles", org)
+    payload = {
+        "profiles": profiles,
+        "cached_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    client = _get_redis_client()
+    if client:
+        try:
+            client.setex(cache_key, ORG_PROFILES_TTL_SECONDS, json.dumps(payload))
+            logger.info(f"Cached {len(profiles)} org profiles for {org} (TTL={ORG_PROFILES_TTL_SECONDS}s)")
+            return
+        except Exception as e:
+            logger.warning(f"Redis write error for org profiles: {e}")
+
+    with _fallback_lock:
+        _fallback_cache[cache_key] = {"profiles": profiles, "timestamp": datetime.now(timezone.utc)}

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -1994,6 +1994,9 @@ class UnifiedBurnoutAnalyzer:
         # Add GitHub activity if available
         if github_data and github_data.get("activity_data"):
             result["github_activity"] = github_data["activity_data"]
+            # Propagate github_username from collected data if not already set
+            if not result.get("github_username") and github_data.get("username"):
+                result["github_username"] = github_data["username"]
 
             # Check if GitHub activity indicates high risk
             github_indicators = github_data.get("activity_data", {}).get("burnout_indicators", {})

--- a/backend/tests/test_github_name_fallback.py
+++ b/backend/tests/test_github_name_fallback.py
@@ -1,0 +1,106 @@
+"""
+Tests for name-based GitHub matching fallback in GitHubCollector._correlate_email_to_github().
+
+Verifies that when synced members and manual mappings both fail,
+the collector falls back to EnhancedGitHubMatcher.match_name_to_github().
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from app.services.github_collector import GitHubCollector
+
+
+@pytest.fixture
+def collector():
+    return GitHubCollector()
+
+
+@pytest.mark.asyncio
+async def test_name_fallback_finds_match(collector):
+    """Name fallback should return a match when synced/manual lookups fail."""
+    with patch.object(collector, '_check_synced_members', new_callable=AsyncMock, return_value=None), \
+         patch.object(collector, '_check_manual_mappings', new_callable=AsyncMock, return_value=None), \
+         patch('app.services.enhanced_github_matcher.EnhancedGitHubMatcher') as MockMatcher:
+
+        instance = MockMatcher.return_value
+        instance.match_name_to_github = AsyncMock(return_value='spencercheng')
+
+        result = await collector._correlate_email_to_github(
+            email='spencer@example.com',
+            token='ghp_test123',
+            user_id=1,
+            full_name='Spencer Cheng',
+        )
+
+        assert result == 'spencercheng'
+        MockMatcher.assert_called_once_with('ghp_test123', collector.organizations)
+        instance.match_name_to_github.assert_awaited_once_with('Spencer Cheng', fallback_email='spencer@example.com')
+
+
+@pytest.mark.asyncio
+async def test_name_fallback_skipped_when_no_full_name(collector):
+    """Fallback should be skipped when full_name is not provided."""
+    with patch.object(collector, '_check_synced_members', new_callable=AsyncMock, return_value=None), \
+         patch.object(collector, '_check_manual_mappings', new_callable=AsyncMock, return_value=None), \
+         patch('app.services.enhanced_github_matcher.EnhancedGitHubMatcher') as MockMatcher:
+
+        result = await collector._correlate_email_to_github(
+            email='spencer@example.com',
+            token='ghp_test123',
+            user_id=1,
+            full_name=None,
+        )
+
+        assert result is None
+        MockMatcher.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_name_fallback_skipped_when_no_token(collector):
+    """Fallback (and entire method) should return None when token is missing."""
+    result = await collector._correlate_email_to_github(
+        email='spencer@example.com',
+        token=None,
+        user_id=1,
+        full_name='Spencer Cheng',
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_name_fallback_handles_exception_gracefully(collector):
+    """If the matcher raises, the method should return None instead of propagating."""
+    with patch.object(collector, '_check_synced_members', new_callable=AsyncMock, return_value=None), \
+         patch.object(collector, '_check_manual_mappings', new_callable=AsyncMock, return_value=None), \
+         patch('app.services.enhanced_github_matcher.EnhancedGitHubMatcher') as MockMatcher:
+
+        instance = MockMatcher.return_value
+        instance.match_name_to_github = AsyncMock(side_effect=RuntimeError('API timeout'))
+
+        result = await collector._correlate_email_to_github(
+            email='spencer@example.com',
+            token='ghp_test123',
+            user_id=1,
+            full_name='Spencer Cheng',
+        )
+
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_synced_member_takes_priority_over_name_fallback(collector):
+    """When synced members returns a match, name fallback should never run."""
+    with patch.object(collector, '_check_synced_members', new_callable=AsyncMock, return_value='spencer-synced'), \
+         patch('app.services.enhanced_github_matcher.EnhancedGitHubMatcher') as MockMatcher:
+
+        result = await collector._correlate_email_to_github(
+            email='spencer@example.com',
+            token='ghp_test123',
+            user_id=1,
+            full_name='Spencer Cheng',
+        )
+
+        assert result == 'spencer-synced'
+        MockMatcher.assert_not_called()

--- a/frontend/src/app/integrations/components/GitHubConnectedCard.tsx
+++ b/frontend/src/app/integrations/components/GitHubConnectedCard.tsx
@@ -228,6 +228,19 @@ export function GitHubConnectedCard({
           </div>
         </div>
 
+        {/* Name Matching Warning */}
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-800">
+          <div className="flex items-start space-x-2">
+            <AlertTriangle className="w-4 h-4 text-amber-500 mt-0.5 flex-shrink-0" />
+            <div>
+              <div className="font-medium mb-1">GitHub accounts are matched by name</div>
+              <div>
+                During analysis, team members are matched to GitHub accounts using name similarity. For the most accurate results, use the <strong>Sync Members</strong> button on the mapping page to confirm matches.
+              </div>
+            </div>
+          </div>
+        </div>
+
         {/* Info Note */}
         <div className="bg-slate-50 border border-slate-200 rounded-lg p-3 text-xs text-slate-600">
           <div className="font-medium mb-1">Data Collection</div>


### PR DESCRIPTION
## Summary

- **Name-based matching fallback**: When synced members and manual mappings fail to find a GitHub username, falls back to `EnhancedGitHubMatcher.match_name_to_github()` which matches by name similarity against org members. Improved match rate from 1/88 (1.1%) to 27+/88 (30%+).
- **Redis-cached org profiles**: GitHub org member profiles (login + display name) cached in Redis with 24h TTL, avoiding ~60 API calls per deploy/restart.
- **Search API throttling**: Processes users in waves of 8 with 65s pauses to stay under GitHub's 30 req/min search API limit.
- **Username propagation**: `github_username` now populated in analysis results from collected data, not just from pre-existing platform mappings.
- **Rate-limit resilience**: When activity data fetch fails (rate limit), returns username-only result instead of discarding the match entirely.
- **Frontend warning**: Amber note on GitHub integration card explaining name-based matching and recommending Sync Members for best accuracy.

## Files changed

- `backend/app/services/github_collector.py` — name fallback in `_correlate_email_to_github()`, username-only fallback result, search API throttling
- `backend/app/services/enhanced_github_matcher.py` — GitHub search API fallback, Redis cache integration for org profiles
- `backend/app/services/github_mapping_service.py` — cache bypass for failed mappings when name available, pass `email_to_name` + `user_id` through
- `backend/app/services/github_org_cache.py` — new Redis-backed cache for org members/profiles (24h TTL)
- `backend/app/services/unified_burnout_analyzer.py` — propagate `github_username` from collected GitHub data
- `frontend/src/app/integrations/components/GitHubConnectedCard.tsx` — amber warning note
- `backend/tests/test_github_name_fallback.py` — 5 tests for fallback behavior

## Test plan

- [x] `pytest tests/test_github_name_fallback.py -v` — all 5 pass
- [ ] Run analysis on testing environment, verify 27+ GitHub matches via SQL query
- [ ] Verify Redis cache populated (`github_org:profiles:rootlyhq` key exists after first run)
- [ ] Verify second analysis skips profile fetching (check logs for Redis HIT)
- [ ] Verify no search API rate limiting (403) with throttling in place