### PR TITLE
feat: Add Super Admin Role for Organization Continuity

### DIFF
--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -559,6 +559,29 @@ async def update_user_role(
             detail="Cannot change your own role"
         )
 
+    # Prevent demoting super admin unless you are also a super admin
+    if target_user.role == 'super_admin' and not current_user.is_super_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only super admins can demote other super admins"
+        )
+
+    # Prevent demoting the last super admin
+    if target_user.role == 'super_admin':
+        super_admin_count = db.query(User).filter(
+            User.organization_id == current_user.organization_id,
+            User.organization_id.isnot(None),
+            User.role == 'super_admin',
+            User.status == 'active',
+            User.id != target_user.id
+        ).count()
+
+        if super_admin_count == 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot demote the last super admin. Promote another admin to super admin first."
+            )
+
     # Prevent demoting the last admin
     if target_user.role == 'admin' and new_role != 'admin':
         admin_count = db.query(User).filter(
@@ -693,6 +716,23 @@ async def delete_current_user_account(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Email confirmation does not match your account email"
         )
+
+    # Prevent deletion if user is the last super admin in the organization
+    if current_user.organization_id and current_user.is_super_admin:
+        other_super_admins = db.query(User).filter(
+            User.organization_id == current_user.organization_id,
+            User.organization_id.isnot(None),
+            User.role == 'super_admin',
+            User.id != current_user.id,
+            User.status == 'active'
+        ).count()
+
+        if other_super_admins == 0:
+            logger.warning(f"Account deletion blocked - user {current_user.id} is the last super admin")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="You are the last super admin. Please promote another admin to super admin before deleting your account."
+            )
 
     # Additional safety check - prevent deletion if user is sole admin WITH other team members
     if current_user.organization_id and current_user.is_admin:
@@ -966,14 +1006,37 @@ async def remove_organization_member(
             detail="User is not in your organization"
         )
 
-    # Safety check 5: If removing an admin, ensure there's at least one other admin
+    # Safety check 5: Only super admins can remove other super admins
+    if target_user.role == 'super_admin' and not current_user.is_super_admin:
+        raise HTTPException(
+            status_code=403,
+            detail="Only super admins can remove other super admins"
+        )
+
+    # Safety check 6: Cannot remove the last super admin
+    if target_user.role == 'super_admin':
+        other_super_admin_count = db.query(User).filter(
+            User.organization_id == current_user.organization_id,
+            User.organization_id.isnot(None),
+            User.role == 'super_admin',
+            User.id != user_id,
+            User.status == 'active'
+        ).count()
+
+        if other_super_admin_count == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot remove the last super admin. Promote another admin to super admin first."
+            )
+
+    # Safety check 7: If removing an admin, ensure there's at least one other admin
     if target_user.role == 'admin':
         # Count other admins in the organization
         # SECURITY: Explicitly check IS NOT NULL to prevent NULL == NULL matching
         other_admin_count = db.query(User).filter(
             User.organization_id == current_user.organization_id,
             User.organization_id.isnot(None),
-            User.role == 'admin',
+            User.role.in_(['admin', 'super_admin']),
             User.id != user_id,
             User.status == 'active'
         ).count()

--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -531,7 +531,7 @@ async def update_user_role(
     new_role = new_role.lower()
 
     # Check if current user is admin
-    if current_user.role != 'admin':
+    if not current_user.is_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only admins can change user roles"
@@ -616,7 +616,7 @@ async def get_promotable_users(
     Used when sole admin needs to promote someone before deleting their account.
     """
     # Check if current user is admin
-    if current_user.role != 'admin':
+    if not current_user.is_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only admins can view promotable users"
@@ -695,12 +695,12 @@ async def delete_current_user_account(
         )
 
     # Additional safety check - prevent deletion if user is sole admin WITH other team members
-    if current_user.organization_id and current_user.role == 'admin':
+    if current_user.organization_id and current_user.is_admin:
         # Check if there are other admins
         other_admins = db.query(User).filter(
             User.organization_id == current_user.organization_id,
             User.organization_id.isnot(None),
-            User.role == 'admin',
+            User.role.in_(['admin', 'super_admin']),
             User.id != current_user.id,
             User.status == 'active'
         ).count()
@@ -935,7 +935,7 @@ async def remove_organization_member(
         )
 
     # Safety check 2: Must be an admin
-    if current_user.role != 'admin':
+    if not current_user.is_admin:
         raise HTTPException(
             status_code=403,
             detail="Only organization admins can remove members"
@@ -1086,5 +1086,87 @@ async def password_login(
             "id": user.id,
             "email": user.email,
             "name": user.name
+        }
+    }
+
+
+class PromoteToSuperAdminRequest(BaseValidatedModel):
+    """Request model for promoting a user to super admin."""
+    target_user_id: int = Field(..., gt=0, description="ID of the user to promote")
+
+
+@router.post("/organizations/promote-to-super-admin")
+async def promote_to_super_admin(
+    request: PromoteToSuperAdminRequest,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+) -> Dict[str, Any]:
+    """
+    Promote another admin to super admin (does not remove current user's super admin status).
+    Only super admins can promote other admins to super admin.
+    This allows organizations to have multiple super admins.
+    """
+    # Check if current user is super admin
+    if not current_user.is_super_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only super admins can promote other admins to super admin"
+        )
+
+    # Check if current user is in an organization
+    if not current_user.organization_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You must be in an organization to promote users to super admin"
+        )
+
+    # Get the target user
+    target_user = db.query(User).filter(
+        User.id == request.target_user_id,
+        User.status == 'active'
+    ).first()
+
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Target user not found"
+        )
+
+    # Check if target user is in the same organization
+    if target_user.organization_id != current_user.organization_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Target user must be in the same organization"
+        )
+
+    # Check if target user is an admin (but not already super admin)
+    if target_user.role not in ['admin', 'super_admin']:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Target user must be an admin to become super admin"
+        )
+
+    # Check if target is already super admin
+    if target_user.is_super_admin:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Target user is already a super admin"
+        )
+
+    # Promote target user to super admin role
+    target_user.role = 'super_admin'
+    db.commit()
+
+    logger.info(
+        f"Super admin promoted: {target_user.id} ({target_user.email}) "
+        f"by {current_user.id} ({current_user.email}) in org {current_user.organization_id}"
+    )
+
+    return {
+        "message": f"Successfully promoted {target_user.name} to super admin",
+        "new_super_admin": {
+            "id": target_user.id,
+            "email": target_user.email,
+            "name": target_user.name
         }
     }

--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -878,6 +878,7 @@ async def get_organization_members(
             "name": user.name,
             "email": user.email,
             "role": user.role,
+            "is_super_admin": user.is_super_admin,
             "status": "active",
             "is_current_user": user.id == current_user.id,
             "joined_at": user.joined_org_at.isoformat() if user.joined_org_at else None

--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -564,7 +564,7 @@ async def update_user_role(
         admin_count = db.query(User).filter(
             User.organization_id == current_user.organization_id,
             User.organization_id.isnot(None),
-            User.role == 'admin',
+            User.role.in_(['admin', 'super_admin']),
             User.status == 'active',
             User.id != target_user.id
         ).count()

--- a/backend/app/api/endpoints/invitations.py
+++ b/backend/app/api/endpoints/invitations.py
@@ -6,10 +6,13 @@ from typing import Dict, Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, EmailStr
+import logging
 
 from ...models import get_db, User, OrganizationInvitation, Organization, UserNotification, OAuthProvider
 from ...auth.dependencies import get_current_active_user, get_current_user_optional
 from ...services.notification_service import NotificationService
+
+logger = logging.getLogger(__name__)
 
 class CreateInvitationRequest(BaseModel):
     email: EmailStr
@@ -34,7 +37,7 @@ async def create_invitation(
         raise HTTPException(status_code=400, detail="You must be part of an organization to invite others")
 
     # Check if user can invite (admin only)
-    if current_user.role != 'admin':
+    if not current_user.is_admin:
         raise HTTPException(status_code=403, detail="Only admins can invite users")
 
     # Check if user already exists with this email
@@ -149,7 +152,7 @@ async def list_pending_invitations(
         raise HTTPException(status_code=400, detail="Invalid email format")
 
     # Check if user can view invitations (admin only)
-    if current_user.role != 'admin':
+    if not current_user.is_admin:
         raise HTTPException(status_code=403, detail="Only organization admins can view invitations")
 
     try:
@@ -231,6 +234,7 @@ async def list_organization_members(
                 "name": member.name,
                 "email": member.email,
                 "role": member.role,
+                "is_super_admin": member.is_super_admin,
                 "joined_org_at": member.joined_org_at.isoformat() if member.joined_org_at else None,
                 "created_at": member.created_at.isoformat() if member.created_at else None,
                 "is_current_user": member.id == current_user.id
@@ -301,6 +305,18 @@ async def accept_invitation_page(
         current_user.organization_id = invitation.organization_id
         current_user.role = invitation.role
         current_user.joined_org_at = datetime.now(timezone.utc)
+
+        # If joining as admin and no other super admins exist, become super admin
+        if invitation.role == 'admin':
+            other_super_admins = db.query(User).filter(
+                User.organization_id == invitation.organization_id,
+                User.role == 'super_admin',
+                User.status == 'active'
+            ).count()
+
+            if other_super_admins == 0:
+                current_user.role = 'super_admin'
+                logger.info(f"User {current_user.email} became first super admin in org {invitation.organization_id} via invitation")
 
         # Mark invitation as accepted
         invitation.status = "accepted"
@@ -384,6 +400,18 @@ async def accept_invitation_api(
         current_user.role = invitation.role
         current_user.joined_org_at = datetime.now(timezone.utc)
 
+        # If joining as admin and no other super admins exist, become super admin
+        if invitation.role == 'admin':
+            other_super_admins = db.query(User).filter(
+                User.organization_id == invitation.organization_id,
+                User.role == 'super_admin',
+                User.status == 'active'
+            ).count()
+
+            if other_super_admins == 0:
+                current_user.role = 'super_admin'
+                logger.info(f"User {current_user.email} became first super admin in org {invitation.organization_id} via invitation")
+
         # Mark invitation as accepted
         invitation.status = "accepted"
         invitation.used_at = datetime.now(timezone.utc)
@@ -465,7 +493,7 @@ async def resend_invitation(
     if (not current_user.organization_id or
         not invitation.organization_id or
         current_user.organization_id != invitation.organization_id or
-        current_user.role != 'admin'):
+        not current_user.is_admin):
         raise HTTPException(status_code=403, detail="Not authorized to resend this invitation")
 
     if invitation.status == "accepted":
@@ -581,7 +609,7 @@ async def revoke_invitation(
         (current_user.organization_id and
          invitation.organization_id and
          current_user.organization_id == invitation.organization_id and
-         current_user.role == 'admin') or
+         current_user.is_admin) or
         current_user.id == invitation.invited_by
     ):
         raise HTTPException(status_code=403, detail="Not authorized to revoke this invitation")

--- a/backend/app/api/endpoints/invitations.py
+++ b/backend/app/api/endpoints/invitations.py
@@ -292,12 +292,23 @@ async def accept_invitation_page(
             detail="This invitation is for a different email address"
         )
 
-    # Check if user is already in an organization
+    # Check if user is switching organizations
     if current_user.organization_id and current_user.organization_id != invitation.organization_id:
-        raise HTTPException(
-            status_code=400,
-            detail="You are already a member of another organization"
-        )
+        # Prevent the last super admin from leaving their organization
+        if current_user.is_super_admin:
+            other_super_admins = db.query(User).filter(
+                User.organization_id == current_user.organization_id,
+                User.organization_id.isnot(None),
+                User.role == 'super_admin',
+                User.id != current_user.id,
+                User.status == 'active'
+            ).count()
+
+            if other_super_admins == 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail="You are the last super admin in your organization. Please promote another admin to super admin before switching organizations."
+                )
 
     # Process acceptance
     try:
@@ -386,12 +397,23 @@ async def accept_invitation_api(
             detail="This invitation is for a different email address"
         )
 
-    # Check if user is already in an organization
+    # Check if user is switching organizations
     if current_user.organization_id and current_user.organization_id != invitation.organization_id:
-        raise HTTPException(
-            status_code=400,
-            detail="You are already a member of another organization"
-        )
+        # Prevent the last super admin from leaving their organization
+        if current_user.is_super_admin:
+            other_super_admins = db.query(User).filter(
+                User.organization_id == current_user.organization_id,
+                User.organization_id.isnot(None),
+                User.role == 'super_admin',
+                User.id != current_user.id,
+                User.status == 'active'
+            ).count()
+
+            if other_super_admins == 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail="You are the last super admin in your organization. Please promote another admin to super admin before switching organizations."
+                )
 
     # Process acceptance
     try:

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -28,7 +28,7 @@ class User(Base):
 
     # Organization and role management
     organization_id = Column(Integer, ForeignKey("organizations.id"), nullable=True)
-    role = Column(String(20), default="member")  # 'admin', 'member'
+    role = Column(String(20), default="member")  # 'super_admin', 'admin', 'member', 'viewer'
     joined_org_at = Column(DateTime(timezone=True), server_default=func.now())
     last_active_at = Column(DateTime(timezone=True))
     status = Column(String(20), default="active")  # 'active', 'suspended', 'pending'
@@ -150,14 +150,19 @@ class User(Base):
 
     # Role-based properties
     @property
+    def is_super_admin(self) -> bool:
+        """Check if user is a super admin."""
+        return self.role == 'super_admin'
+
+    @property
     def is_admin(self) -> bool:
-        """Check if user is an admin."""
-        return self.role == 'admin'
+        """Check if user is an admin (includes super_admin)."""
+        return self.role in ['super_admin', 'admin']
 
     @property
     def is_manager(self) -> bool:
         """Check if user can manage analyses and surveys."""
-        return self.role in ['admin', 'member']
+        return self.role in ['super_admin', 'admin', 'member']
 
     @property
     def is_active(self) -> bool:
@@ -166,7 +171,7 @@ class User(Base):
 
     def can_manage_organization(self, org_id: int = None) -> bool:
         """Check if user can manage organization settings."""
-        if self.role == 'admin' and (org_id is None or self.organization_id == org_id):
+        if self.role in ['super_admin', 'admin'] and (org_id is None or self.organization_id == org_id):
             return True
         return False
 
@@ -185,6 +190,7 @@ class User(Base):
             'email': self.email,
             'name': self.name,
             'role': self.role,
+            'is_super_admin': self.is_super_admin,  # Property that checks role == 'super_admin'
             'status': self.status,
             'is_verified': self.is_verified,
             'created_at': self.created_at.isoformat() if self.created_at else None,

--- a/backend/app/services/account_linking.py
+++ b/backend/app/services/account_linking.py
@@ -428,8 +428,8 @@ class AccountLinkingService:
                 ).count()
 
                 user.organization_id = organization.id
-                # First user is admin, subsequent users are members
-                user.role = 'admin' if existing_users == 0 else 'member'
+                # First user is super admin, subsequent users are members
+                user.role = 'super_admin' if existing_users == 0 else 'member'
                 user.joined_org_at = datetime.now()
 
                 logger.info(f"Auto-assigned {email} to org {organization.id} ({organization.name}) as {user.role}")

--- a/backend/app/services/organization_auto_assignment.py
+++ b/backend/app/services/organization_auto_assignment.py
@@ -153,16 +153,16 @@ def assign_user_to_organization(db: Session, user: User) -> bool:
             logger.info(f"User {user.email} auto-joined existing org '{existing_org.name}' (id={existing_org.id}) as member")
             return True
 
-        # Create new org for this domain, user becomes admin
+        # Create new org for this domain, user becomes super admin
         try:
             new_org = _create_organization_from_domain(db, domain, user)
             user.organization_id = new_org.id
-            user.role = 'admin'  # First user becomes admin
+            user.role = 'super_admin'  # First user becomes super admin
             user.joined_org_at = datetime.now(timezone.utc)
             db.add(user)
             db.commit()
             db.refresh(user)
-            logger.info(f"User {user.email} created new org '{new_org.name}' (id={new_org.id}) and became admin")
+            logger.info(f"User {user.email} created new org '{new_org.name}' (id={new_org.id}) and became super admin")
             return True
         except Exception as e:
             logger.error(f"Failed to create organization for domain {domain}: {e}")

--- a/backend/migrations/2026_02_05_add_super_admin.sql
+++ b/backend/migrations/2026_02_05_add_super_admin.sql
@@ -1,0 +1,45 @@
+-- Migration: Add super admin role for org continuity
+-- Date: 2026-02-05
+-- Description: Promote first admin in each org to super_admin role to ensure org continuity
+
+-- Step 1: Set first admin in each organization as super_admin
+-- This ensures every org has at least one super admin
+WITH first_admins AS (
+    SELECT DISTINCT ON (organization_id)
+        id,
+        organization_id
+    FROM users
+    WHERE
+        organization_id IS NOT NULL
+        AND role = 'admin'
+        AND status = 'active'
+    ORDER BY organization_id, created_at ASC
+)
+UPDATE users
+SET role = 'super_admin'
+WHERE id IN (SELECT id FROM first_admins);
+
+-- Verification queries
+SELECT 'Super admin count per organization:' as info;
+SELECT
+    o.id as org_id,
+    o.name as org_name,
+    COUNT(u.id) as super_admin_count,
+    ARRAY_AGG(u.email) as super_admin_emails
+FROM organizations o
+LEFT JOIN users u ON u.organization_id = o.id AND u.role = 'super_admin' AND u.status = 'active'
+GROUP BY o.id, o.name
+ORDER BY super_admin_count ASC, o.id;
+
+SELECT 'Organizations without super admin (should be empty):' as warning;
+SELECT
+    o.id as org_id,
+    o.name as org_name
+FROM organizations o
+WHERE NOT EXISTS (
+    SELECT 1 FROM users u
+    WHERE u.organization_id = o.id
+    AND u.role = 'super_admin'
+    AND u.status = 'active'
+)
+ORDER BY o.id;

--- a/backend/migrations/2026_02_05_convert_super_admin_flag_to_role.sql
+++ b/backend/migrations/2026_02_05_convert_super_admin_flag_to_role.sql
@@ -1,0 +1,40 @@
+-- Migration: Convert is_super_admin flag to super_admin role
+-- Date: 2026-02-05
+-- Description: Migrate from is_super_admin boolean column to role-based approach
+
+-- Step 1: Convert users with is_super_admin=true to role='super_admin' (only if column exists)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'users' AND column_name = 'is_super_admin'
+    ) THEN
+        UPDATE users
+        SET role = 'super_admin'
+        WHERE is_super_admin = TRUE AND status = 'active';
+    END IF;
+END $$;
+
+-- Step 2: Drop the is_super_admin column
+ALTER TABLE users DROP COLUMN IF EXISTS is_super_admin;
+
+-- Step 3: Drop the index if it exists
+DROP INDEX IF EXISTS idx_users_super_admin;
+
+-- Verification
+SELECT 'Super admin role count:' as info;
+SELECT COUNT(*) as super_admin_count
+FROM users
+WHERE role = 'super_admin' AND status = 'active';
+
+SELECT 'Super admins per organization:' as info;
+SELECT
+    o.id as org_id,
+    o.name as org_name,
+    COUNT(u.id) as super_admin_count,
+    ARRAY_AGG(u.email) as super_admin_emails
+FROM organizations o
+LEFT JOIN users u ON u.organization_id = o.id AND u.role = 'super_admin' AND u.status = 'active'
+GROUP BY o.id, o.name
+ORDER BY super_admin_count ASC, o.id;

--- a/backend/migrations/migration_runner.py
+++ b/backend/migrations/migration_runner.py
@@ -1222,12 +1222,22 @@ class MigrationRunner:
                 "sql_file": "2026_01_26_add_last_modified_to_survey_schedules.sql"
             },
             {
-                "name": "043_add_sync_tracking_to_rootly_integrations",
+                "name": "043_add_super_admin",
+                "description": "Add is_super_admin flag for org continuity - ensures at least one super admin per org",
+                "sql_file": "2026_02_05_add_super_admin.sql"
+            },
+            {
+                "name": "044_convert_super_admin_flag_to_role",
+                "description": "Convert is_super_admin flag to super_admin role - cleaner role-based permissions",
+                "sql_file": "2026_02_05_convert_super_admin_flag_to_role.sql"
+            },
+            {
+                "name": "045_add_sync_tracking_to_rootly_integrations",
                 "description": "Add last_synced_by and last_synced_at columns to track who last synced each integration",
                 "sql_file": "2026_02_06_add_sync_tracking_to_rootly_integrations.sql"
             },
             {
-                "name": "044_optimize_get_platform_mappings",
+                "name": "046_optimize_get_platform_mappings",
                 "description": "Add composite indexes to optimize get_platform_mappings endpoint",
                 "sql_file": "2026_02_06_optimize_get_platform_mappings.sql"
             },

--- a/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
@@ -524,14 +524,8 @@ export function OrganizationManagementDialog({
                                   <option value="admin">Admin</option>
                                 </select>
                               ) : (
-                                <span className="text-sm font-medium capitalize px-3 py-2.5">
-                                  {member.is_super_admin ? (
-                                    <span className="px-2 py-0.5 rounded-full text-xs bg-purple-100 text-purple-700 font-semibold">
-                                      Super Admin
-                                    </span>
-                                  ) : (
-                                    <span className="text-neutral-900">{member.role?.replace('_', ' ') || 'member'}</span>
-                                  )}
+                                <span className="text-sm text-neutral-900 capitalize px-3 py-2.5">
+                                  {member.role?.replace('_', ' ') || 'member'}
                                 </span>
                               )}
                             </td>

--- a/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
@@ -19,6 +19,7 @@ interface OrganizationMember {
   role: string
   status: 'active' | 'pending'
   is_current_user: boolean
+  is_super_admin?: boolean
   joined_at?: string
   invited_at?: string
   expires_at?: string

--- a/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
@@ -514,7 +514,7 @@ export function OrganizationManagementDialog({
                               <span className="text-sm text-neutral-600">{member.email}</span>
                             </td>
                             <td className="py-2 px-6">
-                              {userInfo?.role === 'admin' && !member.is_current_user ? (
+                              {['admin', 'super_admin'].includes(userInfo?.role || '') && !member.is_current_user && !member.is_super_admin ? (
                                 <select
                                   value={member.role || 'member'}
                                   onChange={(e) => onRoleChange(member.id as number, e.target.value)}
@@ -524,14 +524,21 @@ export function OrganizationManagementDialog({
                                   <option value="admin">Admin</option>
                                 </select>
                               ) : (
-                                <span className="text-sm text-neutral-900 capitalize px-3 py-2.5">
+                                <span className={`text-sm font-medium capitalize px-3 py-2.5 inline-flex items-center gap-2 ${
+                                  member.is_super_admin ? 'text-purple-700' : 'text-neutral-900'
+                                }`}>
                                   {member.role?.replace('_', ' ') || 'member'}
+                                  {member.is_super_admin && (
+                                    <span className="px-2 py-0.5 rounded-full text-xs bg-purple-100 text-purple-700 font-semibold">
+                                      Super Admin
+                                    </span>
+                                  )}
                                 </span>
                               )}
                             </td>
                             <td className="py-2 px-6">
                               <div className="flex justify-end">
-                                {!member.is_current_user && userInfo?.role === 'admin' && (
+                                {!member.is_current_user && !member.is_super_admin && ['admin', 'super_admin'].includes(userInfo?.role || '') && (
                                   confirmRemoveUserId === member.id ? (
                                     <div className="flex items-center gap-2">
                                       <Button

--- a/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
@@ -524,14 +524,13 @@ export function OrganizationManagementDialog({
                                   <option value="admin">Admin</option>
                                 </select>
                               ) : (
-                                <span className={`text-sm font-medium capitalize px-3 py-2.5 inline-flex items-center gap-2 ${
-                                  member.is_super_admin ? 'text-purple-700' : 'text-neutral-900'
-                                }`}>
-                                  {member.role?.replace('_', ' ') || 'member'}
-                                  {member.is_super_admin && (
+                                <span className="text-sm font-medium capitalize px-3 py-2.5">
+                                  {member.is_super_admin ? (
                                     <span className="px-2 py-0.5 rounded-full text-xs bg-purple-100 text-purple-700 font-semibold">
                                       Super Admin
                                     </span>
+                                  ) : (
+                                    <span className="text-neutral-900">{member.role?.replace('_', ' ') || 'member'}</span>
                                   )}
                                 </span>
                               )}

--- a/frontend/src/app/integrations/types.ts
+++ b/frontend/src/app/integrations/types.ts
@@ -232,6 +232,7 @@ export interface UserInfo {
   organization_id?: number
   id?: number
   role?: string
+  is_super_admin?: boolean
 }
 
 // Validation Schemas


### PR DESCRIPTION
## Summary

Implements a super admin role to ensure organization continuity and prevent accidental lockouts. The super admin role is the highest permission level in each organization.

## Key Features

- 🔐 Role-based super admin (not a boolean flag)
- 🛡️ Protection against unauthorized role changes
- 🎯 Automatic promotion: First admin in each org becomes super admin
- 🔄 Demotion capability: Super admins can demote other super admins to admin
- ✨ Clean migration strategy with backward compatibility
- 🔒 **NEW**: Comprehensive protections to ensure at least one super admin per org

## Changes

### Backend

**Database Schema:**
- Migration 043: Promotes first admin in each org to super_admin role
- Migration 044: Converts any legacy is_super_admin flags to role (with column existence check)
- Role hierarchy: `super_admin` > `admin` > `member` > `viewer`

**Models (`backend/app/models/user.py`):**
- Added `is_super_admin` property that returns `role == 'super_admin'`
- Updated `is_admin` property to include both admin and super_admin
- Updated `to_dict()` to include `is_super_admin` field for API responses

**API Endpoints - Super Admin Protections:**
- **Role Changes (`PATCH /users/{user_id}/role`):**
  - Only super admins can demote other super admins
  - Cannot demote the last super admin
  - Must promote another admin to super admin first
  
- **Account Deletion (`DELETE /users/me`):**
  - Last super admin cannot delete their account
  - Must promote another admin to super admin first
  
- **Organization Switching (`POST/GET /accept/{invitation_id}`):**
  - Last super admin cannot accept invitations to other organizations
  - Organization switching now allowed (was previously blocked) with protection
  - Must promote another admin to super admin first
  
- **Member Removal (`DELETE /organizations/members/{user_id}`):**
  - Only super admins can remove other super admins
  - Cannot remove the last super admin
  - Must promote another admin to super admin first

- **Promote Endpoint:** `POST /api/organizations/promote-to-super-admin`
  - Allows super admins to promote other admins to super admin
  - Supports multiple super admins per organization

- **Permission Fixes:**
  - All permission checks now use `is_admin` property (includes super_admin)
  - Fixed in auth.py, invitations.py endpoints

**Services:**
- Auto-promote first user in new org to super_admin
- OAuth-linked users become super admin if first in org
- Invitation acceptance promotes to super admin if no super admins exist

### Frontend

**Organization Management Dialog:**
- Display all roles consistently (member, admin, super admin)
- Super admins can manage member roles
- Cannot edit or remove super admin users
- Role dropdown excludes super_admin (set via dedicated promote endpoint)
- Consistent styling across all roles

**API Integration:**
- Added `is_super_admin` field to UserInfo type
- Organization members API includes super admin status

## Migration Strategy

Two-step migration for maximum safety:

1. **Migration 043** (`2026_02_05_add_super_admin.sql`):
   - Promotes first admin in each org to super_admin
   - Safe for both fresh databases and existing data
   - Includes verification queries

2. **Migration 044** (`2026_02_05_convert_super_admin_flag_to_role.sql`):
   - Cleanup migration for production deployment
   - Uses conditional check for column existence before UPDATE
   - Converts any `is_super_admin=true` flags to `role='super_admin'`
   - Drops `is_super_admin` column if it exists

## Safety Checks

✅ Cannot demote super admins without proper authorization
✅ Cannot demote the last super admin
✅ Cannot remove super admins from organization without authorization
✅ Cannot remove the last super admin
✅ Last super admin cannot delete their account
✅ Last super admin cannot switch organizations
✅ Every org guaranteed to have at least one super admin
✅ Migration verification queries included
✅ Backward compatible API (is_super_admin property)

## Test Plan

**Backend:**
- [x] Migration runs successfully on clean database
- [x] First admin in each org becomes super admin
- [x] Cannot demote super admin without being super admin
- [x] Cannot demote the last super admin
- [x] Last super admin cannot delete account
- [x] Last super admin cannot switch orgs via invitation
- [x] Cannot remove last super admin
- [x] Super admin can promote other admins
- [x] API returns is_super_admin field correctly

**Frontend:**
- [x] Super admin displays correctly in management page
- [x] Super admins can manage member roles
- [x] Cannot edit super admin roles via dropdown
- [x] Consistent styling for all role displays

## Breaking Changes

None - fully backward compatible. Existing admins keep their admin role. First admin in each org is automatically promoted to super_admin by migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)