### PR TITLE
Fix duplicate users in team roster and analysis views

### DIFF
--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -3000,9 +3000,10 @@ async def run_analysis_task(
                 integration_id_str = str(integration_id)
                 logger.info(f"BACKGROUND_TASK: Querying UserCorrelation for organization_id={user.organization_id}, integration_id={integration_id_str}")
 
-                # Query all correlations for this organization
+                # Query all correlations for this organization (team roster only)
                 correlations = db.query(UserCorrelation).filter(
-                    UserCorrelation.organization_id == user.organization_id
+                    UserCorrelation.organization_id == user.organization_id,
+                    UserCorrelation.user_id.is_(None)  # Team roster only
                 ).all()
 
                 jira_mapped = [c for c in correlations if c.jira_account_id]

--- a/backend/app/api/endpoints/slack.py
+++ b/backend/app/api/endpoints/slack.py
@@ -587,6 +587,7 @@ async def get_slack_status(
     synced_users_count = db.query(UserCorrelation).filter(
         UserCorrelation.organization_id == current_user.organization_id,
         UserCorrelation.organization_id.isnot(None),
+        UserCorrelation.user_id.is_(None),  # Team roster only
         UserCorrelation.slack_user_id.isnot(None)
     ).count()
 

--- a/backend/app/services/demo_analysis_service.py
+++ b/backend/app/services/demo_analysis_service.py
@@ -208,10 +208,11 @@ def _load_health_checkins_for_user(db: Session, user_id: int, organization_id: i
                 continue
 
             try:
-                # Check if UserCorrelation already exists
+                # Check if UserCorrelation already exists (team roster only)
                 existing = db.query(UserCorrelation).filter(
                     UserCorrelation.organization_id == organization_id,
-                    UserCorrelation.email == email
+                    UserCorrelation.email == email,
+                    UserCorrelation.user_id.is_(None)  # Team roster only
                 ).first()
 
                 if not existing:

--- a/backend/app/services/jira_user_sync_service.py
+++ b/backend/app/services/jira_user_sync_service.py
@@ -192,9 +192,10 @@ class JiraUserSyncService:
         organization_id = current_user.organization_id
         user_id = current_user.id
 
-        # Get all existing UserCorrelation records for this org
+        # Get all existing UserCorrelation records for this org (team roster only)
         existing_correlations = self.db.query(UserCorrelation).filter(
-            UserCorrelation.organization_id == organization_id
+            UserCorrelation.organization_id == organization_id,
+            UserCorrelation.user_id.is_(None)  # Team roster only
         ).all() if organization_id else []
 
         # Also query by user_id for beta mode (no org)

--- a/backend/app/services/user_sync_service.py
+++ b/backend/app/services/user_sync_service.py
@@ -301,20 +301,19 @@ class UserSyncService:
             # This prevents one user from overwriting another user's correlations
 
             # Determine user_id assignment FIRST (before querying)
-            if email.lower() == current_user.email.lower():
-                # Current user's own email always gets user_id=current_user.id
-                assigned_user_id = current_user.id
-                logger.debug(f"Assigning correlation for {email} to current user {current_user.id}")
-            else:
-                # Team members:
-                # - In multi-tenant mode: user_id=NULL (org-scoped roster data)
-                # - In beta mode: user_id=current_user.id (personal isolation)
-                if organization_id:
-                    assigned_user_id = None  # Org-scoped
-                    logger.debug(f"Creating org-scoped correlation for team member {email}")
+            # CHANGED: In org mode, ALL users (including current user) use team roster (user_id=NULL)
+            # This prevents duplicate-looking entries where same email has both personal + roster records
+            if organization_id:
+                # Multi-tenant mode: Everyone is team roster (user_id=NULL)
+                assigned_user_id = None
+                if email.lower() == current_user.email.lower():
+                    logger.debug(f"Creating org-scoped correlation for current user {email} (team roster)")
                 else:
-                    assigned_user_id = current_user.id  # Beta mode: isolate by user_id
-                    logger.debug(f"Creating personal correlation for team member {email} (beta mode)")
+                    logger.debug(f"Creating org-scoped correlation for team member {email}")
+            else:
+                # Beta mode: Personal correlations only (user_id=current_user.id)
+                assigned_user_id = current_user.id
+                logger.debug(f"Creating personal correlation for {email} (beta mode)")
 
             # Query with correct uniqueness key based on assigned_user_id
             if assigned_user_id is not None:
@@ -392,6 +391,11 @@ class UserSyncService:
         for attempt in range(max_retries):
             try:
                 self.db.commit()
+                # MONITORING: Log successful sync stats
+                logger.info(
+                    f"✅ SYNC_SUCCESS: org_id={organization_id}, "
+                    f"created={created}, updated={updated}, skipped={skipped}"
+                )
                 break
             except IntegrityError as e:
                 self.db.rollback()
@@ -403,14 +407,21 @@ class UserSyncService:
                 ])
 
                 if is_duplicate_key:
+                    # MONITORING: Log duplicate attempts with context for alerting
+                    logger.warning(
+                        f"🚨 DUPLICATE_ATTEMPT: org_id={organization_id}, "
+                        f"user_id={user_id}, attempt={attempt+1}/{max_retries}, "
+                        f"created={created}, updated={updated}, error={error_str}"
+                    )
                     if attempt < max_retries - 1:
-                        logger.warning(
-                            f"Duplicate key violation on commit (attempt {attempt+1}/{max_retries}). "
-                            f"Retrying after concurrent insert... Error: {error_str}"
-                        )
+                        logger.warning(f"Retrying after concurrent insert...")
                         continue
                     else:
-                        logger.error(f"Failed to commit after {max_retries} attempts: {e}")
+                        # ALERT: This should rarely happen with proper constraints
+                        logger.error(
+                            f"❌ DUPLICATE_FAILURE: Failed to commit after {max_retries} attempts. "
+                            f"org_id={organization_id}, created={created}, updated={updated}"
+                        )
                         raise
                 else:
                     # Different IntegrityError, don't retry


### PR DESCRIPTION
## Summary
Fixes duplicate user entries appearing in team roster view and dashboard analysis results, plus 3 additional query locations found during audit.

## Problem
Users were appearing multiple times in:
1. Team roster management view (synced-users endpoint)
2. Dashboard analysis results
3. Jira/Slack/Demo queries potentially matching wrong records

Root causes:
- Admin users were getting both personal correlations (user_id=admin_id) AND team roster entries (user_id=NULL)
- Multiple queries weren't filtering for team roster only, returning both record types

## Changes

### 1. Sync behavior fix (user_sync_service.py)
**Before**: Admin's own email got personal correlation, team members got team roster entries
```python
if email.lower() == current_user.email.lower():
    assigned_user_id = current_user.id  # Personal correlation
else:
    assigned_user_id = None  # Team roster
```

**After**: Everyone in org mode gets team roster entries
```python
if organization_id:
    assigned_user_id = None  # Everyone is team roster
```

### 2. Analysis query fix (analyses.py line 3004)
**Before**: Queried all user_correlations
```python
correlations = db.query(UserCorrelation).filter(
    UserCorrelation.organization_id == user.organization_id
).all()
```

**After**: Filter to team roster only
```python
correlations = db.query(UserCorrelation).filter(
    UserCorrelation.organization_id == user.organization_id,
    UserCorrelation.user_id.is_(None)  # Team roster only
).all()
```

### 3. Additional query fixes (from audit)
Applied same `user_id.is_(None)` filter to:
- **jira_user_sync_service.py:196** - Jira user matching
- **slack.py:587** - Synced users count  
- **demo_analysis_service.py:212** - Demo data check

### 4. Enhanced logging
Added searchable markers for monitoring:
- `✅ SYNC_SUCCESS` - sync completed
- `🚨 DUPLICATE_ATTEMPT` - duplicate constraint violation caught
- `❌ DUPLICATE_FAILURE` - persistent failure after retries

## Testing
- [x] Admin user appears once in synced-users list
- [x] New analyses show each user only once
- [x] Admin is included in analysis results
- [x] Team roster queries filter correctly
- [x] Jira matching uses correct records
- [x] Slack count shows accurate number

## Impact
- Future syncs create only team roster entries in org mode
- New analyses won't have duplicates
- Admin users are properly included in team roster
- Jira/Slack/Demo queries consistently use team roster
- Existing analyses with duplicates need to be re-run

## Audit Report
Full audit findings available in `AUDIT_DUPLICATE_FIX.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)