### PR TITLE
Add custom 404 page and e2e test

### DIFF
--- a/frontend/e2e/not-found.spec.ts
+++ b/frontend/e2e/not-found.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Not Found Page', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('renders the 404 page for unknown routes and navigates home', async ({ page }) => {
+    const response = await page.goto('/this-route-should-not-exist');
+
+    expect(response?.status(), 'Unknown route should return 404').toBe(404);
+
+    await expect(page.getByText('Error 404')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Page not found' })).toBeVisible();
+
+    const homeLink = page.getByRole('link', { name: 'Go to home' });
+    await expect(homeLink).toBeVisible();
+    await homeLink.click();
+
+    await expect(page).toHaveURL('/');
+  });
+});

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-purple-50 via-white to-white">
+      <div className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 text-center">
+        <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-purple-700">
+          Error 404
+        </p>
+        <h1 className="font-display text-4xl font-semibold text-neutral-900 sm:text-5xl">
+          Page not found
+        </h1>
+        <p className="mt-4 max-w-xl text-base text-neutral-600 sm:text-lg">
+          The page you requested does not exist or may have moved.
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          <Button asChild size="lg">
+            <Link href="/">Go to home</Link>
+          </Button>
+          <Button asChild size="lg" variant="outline">
+            <Link href="/integrations">View integrations</Link>
+          </Button>
+        </div>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add app-wide Next.js not-found page at frontend/src/app/not-found.tsx
- include clear 404 messaging and actions to return home or go to integrations
- add Playwright coverage for unknown routes in frontend/e2e/not-found.spec.ts

## Testing
- npx playwright test e2e/not-found.spec.ts --project=chromium --no-deps