### PR TITLE
Expand team-scope and org-label updates across dashboard, integrations, and management

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1302,7 +1302,6 @@ function DashboardContent() {
                 {(() => {
                   const selected = integrations.find(i => i.id.toString() === dialogSelectedIntegration)
                   if (selected) {
-                    // Use same logic as integrations page - show integration.name
                     const organizationName = selected.name
                     
                     // Use platform field from backend (not inferred from name)
@@ -1323,9 +1322,14 @@ function DashboardContent() {
                       <div>
                         <div className="flex items-center">
                           <div className={`w-2 h-2 rounded-full mr-2 ${platformColor}`}></div>
-                          <span className="font-medium">
-                            {organizationName}
-                          </span>
+                          <div className="min-w-0">
+                            <span className="font-medium block truncate">{organizationName}</span>
+                            {selected.platform === 'rootly' && selected.team_name && (
+                              <span className="mt-1 inline-flex px-1.5 py-0.5 text-xs font-medium rounded bg-purple-100 text-purple-700">
+                                Team scope: {selected.team_name}
+                              </span>
+                            )}
+                          </div>
                           <Star className="w-4 h-4 text-yellow-500 fill-yellow-500 ml-auto" />
                         </div>
                         <button 

--- a/frontend/src/app/integrations/components/PagerDutyIntegrationForm.tsx
+++ b/frontend/src/app/integrations/components/PagerDutyIntegrationForm.tsx
@@ -4,7 +4,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
-import { HelpCircle, ChevronDown, CheckCircle, AlertCircle, Shield, Plus, Loader2, Eye, EyeOff, Copy, Check } from "lucide-react"
+import { HelpCircle, ChevronDown, CheckCircle, AlertCircle, Shield, Plus, Loader2, Eye, EyeOff, Copy, Check, ChevronUp } from "lucide-react"
 import { UseFormReturn } from "react-hook-form"
 import { PagerDutyFormData, PreviewData } from "../types"
 
@@ -20,6 +20,7 @@ interface PagerDutyIntegrationFormProps {
   isValidToken: (token: string) => boolean
   onCopyToken: (token: string) => void
   copied: boolean
+  onMinimize?: () => void
   errorDetails?: { user_message: string; user_guidance: string; error_code: string } | null
 }
 
@@ -35,6 +36,7 @@ export function PagerDutyIntegrationForm({
   isValidToken,
   onCopyToken,
   copied,
+  onMinimize,
   errorDetails
 }: PagerDutyIntegrationFormProps) {
   const [showInstructions, setShowInstructions] = useState(false)
@@ -74,13 +76,28 @@ export function PagerDutyIntegrationForm({
   return (
     <Card className="border-green-200 max-w-2xl mx-auto">
       <CardHeader className="p-8">
-        <div className="flex items-center space-x-3">
-          <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
-            <span className="text-green-600 font-bold">PD</span>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
+              <span className="text-green-600 font-bold">PD</span>
+            </div>
+            <div>
+              <CardTitle>Add PagerDuty Integration</CardTitle>
+            </div>
           </div>
-          <div>
-            <CardTitle>Add PagerDuty Integration</CardTitle>
-          </div>
+          {onMinimize && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0 text-neutral-500 hover:text-neutral-700"
+              onClick={onMinimize}
+              disabled={isAdding}
+              aria-label="Minimize add integration card"
+            >
+              <ChevronUp className="w-4 h-4" />
+            </Button>
+          )}
         </div>
       </CardHeader>
       <CardContent className="space-y-4 p-8 pt-0">

--- a/frontend/src/app/integrations/components/RootlyIntegrationForm.tsx
+++ b/frontend/src/app/integrations/components/RootlyIntegrationForm.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { HelpCircle, ChevronDown, CheckCircle, AlertCircle, Shield, Plus, Loader2, Eye, EyeOff, Copy, Check, Edit3, Users } from "lucide-react"
+import { HelpCircle, ChevronDown, CheckCircle, AlertCircle, Shield, Plus, Loader2, Eye, EyeOff, Copy, Check, Edit3, Users, ChevronUp } from "lucide-react"
 import { UseFormReturn } from "react-hook-form"
 import { RootlyFormData, PreviewData, RootlyTeam, API_BASE } from "../types"
 
@@ -23,6 +23,7 @@ interface RootlyIntegrationFormProps {
   isValidToken: (token: string) => boolean
   onCopyToken: (token: string) => void
   copied: boolean
+  onMinimize?: () => void
   errorDetails?: { user_message: string; user_guidance: string; error_code: string } | null
 }
 
@@ -39,6 +40,7 @@ export function RootlyIntegrationForm({
   isValidToken,
   onCopyToken,
   copied,
+  onMinimize,
   errorDetails
 }: RootlyIntegrationFormProps) {
   const [showInstructions, setShowInstructions] = useState(false)
@@ -126,13 +128,28 @@ export function RootlyIntegrationForm({
   return (
     <Card className="border-purple-200 max-w-2xl mx-auto">
       <CardHeader className="p-8">
-        <div className="flex items-center space-x-3">
-          <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
-            <Image src="/images/rootly-logo-icon.jpg" alt="Rootly" width={24} height={24} />
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
+              <Image src="/images/rootly-logo-icon.jpg" alt="Rootly" width={24} height={24} />
+            </div>
+            <div>
+              <CardTitle>Add Rootly Integration</CardTitle>
+            </div>
           </div>
-          <div>
-            <CardTitle>Add Rootly Integration</CardTitle>
-          </div>
+          {onMinimize && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0 text-neutral-500 hover:text-neutral-700"
+              onClick={onMinimize}
+              disabled={isAdding}
+              aria-label="Minimize add integration card"
+            >
+              <ChevronUp className="w-4 h-4" />
+            </Button>
+          )}
         </div>
       </CardHeader>
       <CardContent className="space-y-4 p-8 pt-0">

--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -637,6 +637,7 @@ export default function IntegrationsPage() {
   
   // Add integration state
   const [addingPlatform, setAddingPlatform] = useState<"rootly" | "pagerduty" | null>(null)
+  const [minimizedAddPlatform, setMinimizedAddPlatform] = useState<"rootly" | "pagerduty" | null>(null)
   const [isShowingToken, setIsShowingToken] = useState(false)
   const [isTestingConnection, setIsTestingConnection] = useState(false)
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'success' | 'error' | 'duplicate'>('idle')
@@ -648,9 +649,6 @@ export default function IntegrationsPage() {
   const [isAddingPagerDuty, setIsAddingPagerDuty] = useState(false)
   const [copied, setCopied] = useState(false)
 
-  // Ref for scrolling to form
-  const formSectionRef = useRef<HTMLDivElement>(null)
-  
   // Edit/Delete state
   const [editingIntegration, setEditingIntegration] = useState<number | null>(null)
   const [editingName, setEditingName] = useState("")
@@ -2181,9 +2179,10 @@ export default function IntegrationsPage() {
     }
   }, [activeEnhancementTab])
 
-  // Close active incident management tab and form when clicking outside
+  // Close active incident management tab when clicking outside.
+  // If add modal is open, keep tab selection stable and let modal handle closure.
   useEffect(() => {
-    if (!activeTab && !addingPlatform) return
+    if (!activeTab || addingPlatform) return
 
     const handleMouseDown = (event: MouseEvent) => {
       // If the click target was detached from the DOM before mousedown fired
@@ -2194,7 +2193,6 @@ export default function IntegrationsPage() {
       const incidentSection = document.querySelector('[data-incident-section]')
       if (incidentSection && !incidentSection.contains(event.target as Node)) {
         setActiveTab(null)
-        setAddingPlatform(null)
       }
     }
 
@@ -2259,6 +2257,7 @@ export default function IntegrationsPage() {
                 onClick={() => {
                   setActiveTab('rootly')
                   setAddingPlatform('rootly')
+                  setMinimizedAddPlatform(null)
                   // Reset connection state when switching platforms
                   setConnectionStatus('idle')
                   setPreviewData(null)
@@ -2310,6 +2309,7 @@ export default function IntegrationsPage() {
               onClick={() => {
                 setActiveTab('pagerduty')
                 setAddingPlatform('pagerduty')
+                setMinimizedAddPlatform(null)
                 // Reset connection state when switching platforms
                 setConnectionStatus('idle')
                 setPreviewData(null)
@@ -2340,57 +2340,91 @@ export default function IntegrationsPage() {
           ))}
         </div>
 
-        <div ref={formSectionRef} className="space-y-6 scroll-mt-20">
-
-            {/* Add Rootly Integration Form */}
-            {addingPlatform === 'rootly' && (
-              <RootlyIntegrationForm
-                form={rootlyForm}
-                onTest={testConnection}
-                onAdd={() => addIntegration('rootly')}
-                onTeamSelect={(teamName, memberCount) => setPreviewData(prev => {
-                  if (!prev) return prev
-                  if (teamName) {
-                    // Save the original org-wide count the first time a team is selected
-                    if (orgTotalUsersRef.current === null) {
-                      orgTotalUsersRef.current = prev.total_users
-                    }
-                    return { ...prev, team_name: teamName, total_users: memberCount ?? prev.total_users }
-                  } else {
-                    // Restore org-wide count when "all teams" is re-selected
-                    const restored = orgTotalUsersRef.current ?? prev.total_users
-                    orgTotalUsersRef.current = null
-                    return { ...prev, team_name: undefined, total_users: restored }
-                  }
-                })}
-                connectionStatus={connectionStatus}
-                previewData={previewData}
-                duplicateInfo={duplicateInfo}
-                isTestingConnection={isTestingConnection}
-                isAdding={isAddingRootly}
-                isValidToken={isValidRootlyToken}
-                onCopyToken={copyToClipboard}
-                copied={copied}
-                errorDetails={errorDetails}
-              />
+        <div className="space-y-6 scroll-mt-20">
+            {addingPlatform === null && minimizedAddPlatform && (
+              <Card className="max-w-2xl mx-auto border-neutral-300 bg-white">
+                <CardContent className="py-3 px-4">
+                  <button
+                    type="button"
+                    className="w-full flex items-center justify-between text-left"
+                    onClick={() => {
+                      setAddingPlatform(minimizedAddPlatform)
+                      setMinimizedAddPlatform(null)
+                    }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <Key className="w-4 h-4 text-purple-600" />
+                      <span className="text-sm font-medium text-neutral-800">
+                        Continue setting up your {minimizedAddPlatform === "rootly" ? "Rootly" : "PagerDuty"} token
+                      </span>
+                    </div>
+                    <span className="text-xs font-medium text-purple-700">Expand</span>
+                  </button>
+                </CardContent>
+              </Card>
             )}
 
-            {/* Add PagerDuty Integration Form */}
+            {/* Add Rootly Integration Form (accordion-style inline card) */}
+            {addingPlatform === 'rootly' && (
+              <>
+                <RootlyIntegrationForm
+                  form={rootlyForm}
+                  onTest={testConnection}
+                  onAdd={() => addIntegration('rootly')}
+                  onMinimize={() => {
+                    setAddingPlatform(null)
+                    setMinimizedAddPlatform('rootly')
+                  }}
+                  onTeamSelect={(teamName, memberCount) => setPreviewData(prev => {
+                    if (!prev) return prev
+                    if (teamName) {
+                      // Save the original org-wide count the first time a team is selected
+                      if (orgTotalUsersRef.current === null) {
+                        orgTotalUsersRef.current = prev.total_users
+                      }
+                      return { ...prev, team_name: teamName, total_users: memberCount ?? prev.total_users }
+                    } else {
+                      // Restore org-wide count when "all teams" is re-selected
+                      const restored = orgTotalUsersRef.current ?? prev.total_users
+                      orgTotalUsersRef.current = null
+                      return { ...prev, team_name: undefined, total_users: restored }
+                    }
+                  })}
+                  connectionStatus={connectionStatus}
+                  previewData={previewData}
+                  duplicateInfo={duplicateInfo}
+                  isTestingConnection={isTestingConnection}
+                  isAdding={isAddingRootly}
+                  isValidToken={isValidRootlyToken}
+                  onCopyToken={copyToClipboard}
+                  copied={copied}
+                  errorDetails={errorDetails}
+                />
+              </>
+            )}
+
+            {/* Add PagerDuty Integration Form (accordion-style inline card) */}
             {addingPlatform === 'pagerduty' && (
-              <PagerDutyIntegrationForm
-                form={pagerdutyForm}
-                onTest={testConnection}
-                onAdd={() => addIntegration('pagerduty')}
-                connectionStatus={connectionStatus}
-                previewData={previewData}
-                duplicateInfo={duplicateInfo}
-                isTestingConnection={isTestingConnection}
-                isAdding={isAddingPagerDuty}
-                isValidToken={isValidPagerDutyToken}
-                onCopyToken={copyToClipboard}
-                copied={copied}
-                errorDetails={errorDetails}
-              />
+              <>
+                <PagerDutyIntegrationForm
+                  form={pagerdutyForm}
+                  onTest={testConnection}
+                  onAdd={() => addIntegration('pagerduty')}
+                  onMinimize={() => {
+                    setAddingPlatform(null)
+                    setMinimizedAddPlatform('pagerduty')
+                  }}
+                  connectionStatus={connectionStatus}
+                  previewData={previewData}
+                  duplicateInfo={duplicateInfo}
+                  isTestingConnection={isTestingConnection}
+                  isAdding={isAddingPagerDuty}
+                  isValidToken={isValidPagerDutyToken}
+                  onCopyToken={copyToClipboard}
+                  copied={copied}
+                  errorDetails={errorDetails}
+                />
+              </>
             )}
 
             {/* Existing Integrations */}
@@ -2515,7 +2549,7 @@ export default function IntegrationsPage() {
                                     <span className="font-medium text-sm sm:text-base truncate">{selected.name}</span>
                                     {selected.platform === 'rootly' && selected.team_name && (
                                       <span className="px-1.5 py-0.5 text-xs font-medium rounded bg-purple-100 text-purple-700 flex-shrink-0">
-                                        {selected.key_type === 'global' ? 'Scope' : 'Team'}: {selected.team_name}
+                                        Team: {selected.team_name}
                                       </span>
                                     )}
                                   </div>
@@ -2553,7 +2587,7 @@ export default function IntegrationsPage() {
                                       <span className="font-medium text-sm sm:text-base truncate">{integration.name}</span>
                                       {integration.platform === 'rootly' && integration.team_name && (
                                         <span className="px-1.5 py-0.5 text-xs font-medium rounded bg-purple-100 text-purple-700 flex-shrink-0">
-                                          {integration.key_type === 'global' ? 'Scope' : 'Team'}: {integration.team_name}
+                                          Team: {integration.team_name}
                                         </span>
                                       )}
                                       {hasPermissionIssues && (
@@ -2612,6 +2646,11 @@ export default function IntegrationsPage() {
                   <div className="space-y-2">
                     {filteredIntegrations.map((integration) => {
                       const isExpanded = expandedIntegrations.has(integration.id)
+                      const rootlyScopeLabel = integration.platform === 'rootly'
+                        ? (integration.team_name
+                          ? `Team: ${integration.team_name}`
+                          : 'Team: All users')
+                        : null
 
                       return (
                       <div key={integration.id} className={`
@@ -2684,15 +2723,16 @@ export default function IntegrationsPage() {
                               <Users className="w-3 h-3" />
                               <span>{integration.total_users}</span>
                             </div>
+                            {rootlyScopeLabel && (
+                              <div className="w-44 flex-shrink-0 hidden lg:block">
+                                <span className="inline-flex items-center rounded bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700">
+                                  {rootlyScopeLabel}
+                                </span>
+                              </div>
+                            )}
                             <div className="text-sm text-neutral-500 w-28 flex-shrink-0 hidden md:block">•••{integration.token_suffix}</div>
                           </>
                         )}
-
-                        {/* Badge - fixed width for alignment */}
-                        <Badge variant={integration.platform === 'rootly' ? 'default' : 'secondary'}
-                               className={`flex-shrink-0 w-24 justify-center ${integration.platform === 'rootly' ? 'bg-purple-100 text-purple-700' : 'bg-green-100 text-green-700'}`}>
-                          {integration.platform}
-                        </Badge>
                       </div>
 
                       {/* Expanded Details */}
@@ -2730,14 +2770,14 @@ export default function IntegrationsPage() {
                                 <div className="text-neutral-700">{integration.total_users}</div>
                               </div>
                             </div>
-                            {integration.platform === 'rootly' && integration.team_name && (
+                            {integration.platform === 'rootly' && (
                               <div className="flex items-start space-x-2">
                                 <Shield className="w-4 h-4 mt-0.5 text-purple-500" />
                                 <div>
-                                  <div className="font-bold text-neutral-900">
-                                    {integration.key_type === 'global' ? 'Team Scope' : 'Team'}
+                                  <div className="font-bold text-neutral-900">Team</div>
+                                  <div className="text-purple-700 font-medium">
+                                    {integration.team_name || 'All users'}
                                   </div>
-                                  <div className="text-purple-700 font-medium">{integration.team_name}</div>
                                 </div>
                               </div>
                             )}

--- a/frontend/src/app/management/page.tsx
+++ b/frontend/src/app/management/page.tsx
@@ -814,6 +814,10 @@ function TeamPageContent() {
   const selectedIntegration = selectedOrganization
     ? integrations.find(i => i.id.toString() === selectedOrganization)
     : null
+  const getTeamScopeLabel = (integration: Integration) => {
+    if (integration.platform !== "rootly") return null
+    return `Team: ${integration.team_name || "All users"}`
+  }
 
   // Check if any primary integration (Rootly or PagerDuty) exists
   // Since the integrations array only contains Rootly and PagerDuty entries, length > 0 is sufficient
@@ -1061,13 +1065,33 @@ function TeamPageContent() {
                               onValueChange={setSelectedOrganization}
                               disabled={loadingIntegrations || !hasPrimaryIntegration}
                             >
-                              <SelectTrigger className="w-64">
-                                <SelectValue placeholder="Select an organization..." />
+                              <SelectTrigger className="w-full sm:w-72">
+                                <SelectValue placeholder="Select an organization...">
+                                  {selectedIntegration && (
+                                    <div className="flex items-center gap-2 min-w-0">
+                                      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${selectedIntegration.platform === "rootly" ? "bg-purple-500" : "bg-green-500"}`}></span>
+                                      <span className="truncate">{selectedIntegration.name || `Integration #${selectedIntegration.id}`}</span>
+                                      {getTeamScopeLabel(selectedIntegration) && (
+                                        <span className="ml-auto inline-flex max-w-[140px] items-center truncate rounded bg-purple-100 px-1.5 py-0.5 text-[11px] font-medium text-purple-700 flex-shrink-0">
+                                          {getTeamScopeLabel(selectedIntegration)}
+                                        </span>
+                                      )}
+                                    </div>
+                                  )}
+                                </SelectValue>
                               </SelectTrigger>
                               <SelectContent>
                                 {integrations.map((integration) => (
                                   <SelectItem key={integration.id} value={integration.id.toString()}>
-                                    {integration.name || `Integration #${integration.id}`}
+                                    <div className="flex items-center gap-2 min-w-0">
+                                      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${integration.platform === "rootly" ? "bg-purple-500" : "bg-green-500"}`}></span>
+                                      <span className="truncate">{integration.name || `Integration #${integration.id}`}</span>
+                                      {getTeamScopeLabel(integration) && (
+                                        <span className="ml-auto inline-flex max-w-[140px] items-center truncate rounded bg-purple-100 px-1.5 py-0.5 text-[11px] font-medium text-purple-700 flex-shrink-0">
+                                          {getTeamScopeLabel(integration)}
+                                        </span>
+                                      )}
+                                    </div>
                                   </SelectItem>
                                 ))}
                               </SelectContent>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -9,6 +9,8 @@ export interface Integration {
   last_used_at: string | null
   token_suffix: string
   platform?: 'rootly' | 'pagerduty'
+  key_type?: string
+  team_name?: string
   permissions?: {
     users?: {
       access: boolean
@@ -424,4 +426,3 @@ export interface AnalysisResult {
 }
 
 export type AnalysisStage = "loading" | "connecting" | "fetching_users" | "fetching" | "fetching_github" | "fetching_slack" | "calculating" | "analyzing" | "preparing" | "complete"
-


### PR DESCRIPTION
## Summary
- show team scope as a pill under the organization name in the Start New Analysis modal
- keep the organization row layout cleaner by placing scope metadata on a second line
- propagate organization/team-scope display and related integration handling updates across integrations and management pages
- align shared integration typing with optional team-scope fields used by dashboard/integrations

## Files Updated
- frontend/src/app/dashboard/page.tsx
- frontend/src/app/integrations/components/PagerDutyIntegrationForm.tsx
- frontend/src/app/integrations/components/RootlyIntegrationForm.tsx
- frontend/src/app/integrations/page.tsx
- frontend/src/app/management/page.tsx
- frontend/src/lib/types.ts