### PR TITLE
fix: share scheduled Slack surveys across org tokens

### DIFF
--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -20,6 +20,7 @@ from ...core.rate_limiting import analysis_rate_limit, general_rate_limit
 from ...core.input_validation import AnalysisRequest as ValidatedAnalysisRequest, AnalysisFilterRequest
 from ...core.alert_health_calculator import calculate_alert_health_score
 from ...core.och_config import apply_alert_health_to_och, OCHConfig
+from ...services.survey_response_service import extract_analysis_member_emails, normalize_survey_email
 from ...utils.visual_logger import log_task_start, log_task_complete
 
 logger = logging.getLogger(__name__)
@@ -887,8 +888,6 @@ def get_member_surveys(analysis: Analysis, db: Session) -> dict:
     from datetime import timedelta, datetime
     from collections import defaultdict
     from ...models.user_burnout_report import UserBurnoutReport
-    from ...models.user_correlation import UserCorrelation
-
     if not analysis.organization_id:
         return {}
 
@@ -896,21 +895,14 @@ def get_member_surveys(analysis: Analysis, db: Session) -> dict:
     analysis_end_date = datetime.now(timezone.utc)
     analysis_start_date = analysis.created_at - timedelta(days=analysis.time_range or 30)
 
-    # Query 1: Get all team member emails (select only email column to avoid loading full objects)
-    # SECURITY: Explicitly check IS NOT NULL for defense-in-depth
-    member_emails = [
-        row[0] for row in db.query(UserCorrelation.email).filter(
-            UserCorrelation.organization_id == analysis.organization_id,
-            UserCorrelation.organization_id.isnot(None),
-            UserCorrelation.email.isnot(None)
-        ).all()
-    ]
+    # Only use the emails that are actually present in this analysis roster.
+    member_emails = extract_analysis_member_emails(analysis.results)
     if not member_emails:
         return {}
 
     # Query 2: Bulk fetch all surveys for all members (instead of N queries)
     all_surveys = db.query(UserBurnoutReport).filter(
-        UserBurnoutReport.email.in_(member_emails),
+        func.lower(UserBurnoutReport.email).in_(member_emails),
         UserBurnoutReport.submitted_at >= analysis_start_date,
         UserBurnoutReport.submitted_at <= analysis_end_date
     ).order_by(UserBurnoutReport.email, UserBurnoutReport.submitted_at.asc()).all()
@@ -918,7 +910,9 @@ def get_member_surveys(analysis: Analysis, db: Session) -> dict:
     # Group surveys by email
     surveys_by_email = defaultdict(list)
     for survey in all_surveys:
-        surveys_by_email[survey.email].append(survey)
+        normalized_email = normalize_survey_email(survey.email)
+        if normalized_email:
+            surveys_by_email[normalized_email].append(survey)
 
     # Process each member's surveys
     member_surveys = {}

--- a/backend/app/api/endpoints/rootly.py
+++ b/backend/app/api/endpoints/rootly.py
@@ -15,6 +15,10 @@ from ...core.rootly_client import RootlyAPIClient
 from ...core.rate_limiting import integration_rate_limit
 from ...core.input_validation import RootlyTokenRequest, RootlyIntegrationRequest
 from ...services.integration_validator import decrypt_token
+from ...services.survey_recipient_service import (
+    get_saved_recipient_ids_for_org,
+    save_survey_recipient_ids_for_org,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1689,18 +1693,21 @@ async def get_synced_users(
 
         # Get saved recipient IDs if configured
         saved_recipient_ids = None
-        if integration_id and surveys_enabled:
-            try:
-                numeric_id = int(integration_id)
-                # SECURITY: Verify user owns this integration
-                integration = db.query(RootlyIntegration).filter(
-                    RootlyIntegration.id == numeric_id,
-                    RootlyIntegration.user_id == current_user.id
-                ).first()
-                if integration and integration.survey_recipients:
-                    saved_recipient_ids = set(integration.survey_recipients)
-            except (ValueError, AttributeError):
-                pass
+        if surveys_enabled:
+            if current_user.organization_id:
+                saved_recipient_ids = get_saved_recipient_ids_for_org(db, current_user.organization_id)
+            elif integration_id:
+                try:
+                    numeric_id = int(integration_id)
+                    # SECURITY: Verify user owns this integration
+                    integration = db.query(RootlyIntegration).filter(
+                        RootlyIntegration.id == numeric_id,
+                        RootlyIntegration.user_id == current_user.id
+                    ).first()
+                    if integration and integration.survey_recipients:
+                        saved_recipient_ids = set(integration.survey_recipients)
+                except (ValueError, AttributeError):
+                    pass
 
         # Format the response
         synced_users = []
@@ -1833,7 +1840,7 @@ async def update_survey_recipients(
     db: Session = Depends(get_db)
 ):
     """
-    Save selected survey recipients for an integration.
+    Save selected survey recipients for automated Slack surveys.
     These users will receive automated burnout survey invitations via Slack.
 
     If recipient_ids is empty, this will RESET to default behavior (send to all users).
@@ -1867,9 +1874,13 @@ async def update_survey_recipients(
                 detail="Integration not found"
             )
 
+        normalized_recipient_ids = [int(recipient_id) for recipient_id in recipient_ids]
+
         # If empty list, set to None to revert to default behavior
-        if len(recipient_ids) == 0:
+        if len(normalized_recipient_ids) == 0:
             integration.survey_recipients = None
+            if current_user.organization_id:
+                save_survey_recipient_ids_for_org(db, current_user.organization_id, None)
             db.commit()
             logger.info(
                 f"User {current_user.id} cleared survey recipients for integration {integration_id} - "
@@ -1889,31 +1900,35 @@ async def update_survey_recipients(
         valid_ids = db.query(UserCorrelation.id).filter(
             UserCorrelation.organization_id.isnot(None),
             UserCorrelation.organization_id == current_user.organization_id,
-            UserCorrelation.id.in_(recipient_ids)
+            UserCorrelation.id.in_(normalized_recipient_ids)
         ).all()
         valid_id_set = {row[0] for row in valid_ids}
 
-        invalid_ids = [rid for rid in recipient_ids if rid not in valid_id_set]
+        invalid_ids = [rid for rid in normalized_recipient_ids if rid not in valid_id_set]
         if invalid_ids:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid recipient IDs: {invalid_ids}"
             )
 
-        # Update the integration with new recipients
-        integration.survey_recipients = recipient_ids
+        # Save the org-wide selection first, then mirror it on the integration for
+        # legacy compatibility with any older readers that still inspect the row.
+        if current_user.organization_id:
+            save_survey_recipient_ids_for_org(db, current_user.organization_id, normalized_recipient_ids)
+
+        integration.survey_recipients = normalized_recipient_ids
         db.commit()
 
         logger.info(
             f"User {current_user.id} updated survey recipients for integration {integration_id}: "
-            f"{len(recipient_ids)} recipients selected"
+            f"{len(normalized_recipient_ids)} recipients selected"
         )
 
         return {
             "success": True,
-            "message": f"Survey recipients updated: {len(recipient_ids)} users selected",
+            "message": f"Survey recipients updated: {len(normalized_recipient_ids)} users selected",
             "integration_id": integration_id,
-            "recipient_count": len(recipient_ids),
+            "recipient_count": len(normalized_recipient_ids),
             "is_default": False
         }
 
@@ -1935,8 +1950,8 @@ async def get_survey_recipients(
     db: Session = Depends(get_db)
 ):
     """
-    Get saved survey recipients for an integration.
-    Returns list of UserCorrelation IDs that should receive surveys.
+    Get saved survey recipients for automated Slack surveys.
+    Returns list of UserCorrelation IDs that should receive scheduled surveys.
     """
     try:
         # Handle beta integrations
@@ -1971,6 +1986,9 @@ async def get_survey_recipients(
             )
 
         recipient_ids = integration.survey_recipients or []
+        if current_user.organization_id:
+            saved_recipient_ids = get_saved_recipient_ids_for_org(db, current_user.organization_id)
+            recipient_ids = sorted(saved_recipient_ids) if saved_recipient_ids is not None else []
 
         return {
             "integration_id": integration_id,

--- a/backend/app/api/endpoints/slack.py
+++ b/backend/app/api/endpoints/slack.py
@@ -3,6 +3,7 @@ Slack integration API endpoints for OAuth and data collection.
 """
 from fastapi import APIRouter, Depends, HTTPException, status, Form
 from sqlalchemy.orm import Session
+from sqlalchemy import func, or_
 from typing import Dict, Any
 import secrets
 import json
@@ -19,6 +20,11 @@ from ...auth.dependencies import get_current_user
 from ...auth.integration_oauth import slack_integration_oauth
 from ...core.config import settings
 from ...services.notification_service import NotificationService
+from ...services.survey_response_service import (
+    extract_analysis_member_emails,
+    get_utc_day_bounds,
+    normalize_survey_email,
+)
 from ...utils import mask_email
 
 # Set up logger
@@ -1511,14 +1517,16 @@ async def handle_slack_interactions(
                     # If no user account but we have email, check for existing report by email
                     existing_report = None
                     if user and user.email:
+                        normalized_email = normalize_survey_email(user.email)
                         existing_report = db.query(UserBurnoutReport).filter(
-                            UserBurnoutReport.email == user.email,
+                            func.lower(UserBurnoutReport.email) == normalized_email,
                             UserBurnoutReport.submitted_at >= today_start
                         ).first()
                     elif user_email:
+                        normalized_email = normalize_survey_email(user_email)
                         # Synced member without user account - check by email
                         existing_report = db.query(UserBurnoutReport).filter(
-                            UserBurnoutReport.email == user_email,
+                            func.lower(UserBurnoutReport.email) == normalized_email,
                             UserBurnoutReport.submitted_at >= today_start
                         ).first()
 
@@ -1636,21 +1644,21 @@ async def handle_slack_interactions(
                 # Determine email to use for report
                 report_email = None
                 if user and user.email:
-                    report_email = user.email
+                    report_email = normalize_survey_email(user.email)
                 elif user_email:
                     # Synced member without user account
                     # Validate email format
                     if '@' not in user_email or len(user_email) < 3:
                         logging.error(f"Invalid email format: '{user_email}'")
                         return {"response_action": "errors", "errors": {"comments_block": "Invalid email format"}}
-                    report_email = user_email
+                    report_email = normalize_survey_email(user_email)
                 else:
                     return {"response_action": "errors", "errors": {"comments_block": "Unable to identify user email"}}
 
                 # Check if user already submitted today (match by email)
                 # This allows only 1 survey per user per day, regardless of organization
                 existing_report = db.query(UserBurnoutReport).filter(
-                    UserBurnoutReport.email == report_email,
+                    func.lower(UserBurnoutReport.email) == report_email,
                     UserBurnoutReport.submitted_at >= today_start
                 ).order_by(UserBurnoutReport.submitted_at.desc()).first()
 
@@ -1666,7 +1674,10 @@ async def handle_slack_interactions(
                     existing_report.personal_circumstances = personal_circumstances
                     existing_report.additional_comments = comments
                     existing_report.submitted_via = 'slack'
-                    existing_report.analysis_id = analysis_id  # Update linked analysis if provided
+                    if analysis_id is not None:
+                        existing_report.analysis_id = analysis_id
+                    if organization_id is not None:
+                        existing_report.organization_id = organization_id
                     existing_report.email = report_email  # Refresh email in case it changed
                     existing_report.email_domain = email_domain  # Refresh email_domain
                     existing_report.user_id = user_id  # Update user_id if they created an account
@@ -1772,8 +1783,9 @@ async def submit_slack_burnout_survey(
     """
     try:
         # Find the user by email
+        report_email = normalize_survey_email(submission.user_email)
         user_correlation = db.query(UserCorrelation).filter(
-            UserCorrelation.email == submission.user_email.lower()
+            func.lower(UserCorrelation.email) == report_email
         ).first()
 
         if not user_correlation:
@@ -1793,46 +1805,61 @@ async def submit_slack_burnout_survey(
                 detail="Analysis not found"
             )
 
-        # Check for duplicate submission (match by email)
-        existing_report = db.query(UserBurnoutReport).filter(
-            UserBurnoutReport.email == submission.user_email.lower(),
-            UserBurnoutReport.analysis_id == submission.analysis_id
-        ).first()
+        today_start, _ = get_utc_day_bounds()
 
-        if existing_report:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Survey already submitted for this analysis"
-            )
+        # One Slack survey response per person per day, regardless of which
+        # analysis/token/org path they came from.
+        existing_report = db.query(UserBurnoutReport).filter(
+            func.lower(UserBurnoutReport.email) == report_email,
+            UserBurnoutReport.submitted_at >= today_start
+        ).order_by(UserBurnoutReport.submitted_at.desc()).first()
 
         # Get user for email_domain
         user = db.query(User).filter(User.id == user_correlation.user_id).first()
+        email_domain = user.email_domain if user else None
 
-        # Create new burnout report
-        new_report = UserBurnoutReport(
-            user_id=user_correlation.user_id,
-            email=submission.user_email.lower(),  # Save email for team member identification
-            organization_id=None,  # No org_id for this endpoint
-            email_domain=user.email_domain if user else None,
-            analysis_id=submission.analysis_id,
-            feeling_score=submission.feeling_score,
-            workload_score=submission.workload_score,
-            stress_factors=submission.stress_factors,
-            personal_circumstances=submission.personal_circumstances,
-            additional_comments=submission.additional_comments,
-            submitted_via='slack',
-            is_anonymous=submission.is_anonymous
-        )
+        if existing_report:
+            existing_report.user_id = user_correlation.user_id
+            existing_report.email = report_email
+            existing_report.organization_id = analysis.organization_id
+            existing_report.email_domain = email_domain
+            if submission.analysis_id is not None:
+                existing_report.analysis_id = submission.analysis_id
+            existing_report.feeling_score = submission.feeling_score
+            existing_report.workload_score = submission.workload_score
+            existing_report.stress_factors = submission.stress_factors
+            existing_report.personal_circumstances = submission.personal_circumstances
+            existing_report.additional_comments = submission.additional_comments
+            existing_report.submitted_via = 'slack'
+            existing_report.is_anonymous = submission.is_anonymous
+            db.commit()
+            db.refresh(existing_report)
+            report = existing_report
+        else:
+            report = UserBurnoutReport(
+                user_id=user_correlation.user_id,
+                email=report_email,
+                organization_id=analysis.organization_id,
+                email_domain=email_domain,
+                analysis_id=submission.analysis_id,
+                feeling_score=submission.feeling_score,
+                workload_score=submission.workload_score,
+                stress_factors=submission.stress_factors,
+                personal_circumstances=submission.personal_circumstances,
+                additional_comments=submission.additional_comments,
+                submitted_via='slack',
+                is_anonymous=submission.is_anonymous
+            )
 
-        db.add(new_report)
-        db.commit()
-        db.refresh(new_report)
+            db.add(report)
+            db.commit()
+            db.refresh(report)
 
         return {
             "success": True,
             "message": "Survey submitted successfully!",
-            "report_id": new_report.id,
-            "submitted_at": new_report.submitted_at.isoformat()
+            "report_id": report.id,
+            "submitted_at": report.submitted_at.isoformat()
         }
 
     except HTTPException:
@@ -1868,17 +1895,33 @@ async def get_team_survey_status(
                 detail="Analysis not found"
             )
 
-        # Get all survey responses for this analysis
-        survey_responses = db.query(UserBurnoutReport).filter(
-            UserBurnoutReport.analysis_id == analysis_id
-        ).all()
+        # Get team members from the analysis results. A scheduled survey response
+        # should count anywhere this member appears, not only on a single
+        # analysis_id-linked report row.
+        team_members = extract_analysis_member_emails(analysis.results)
+        today_start, _ = get_utc_day_bounds()
 
-        # Get team members from the analysis results
-        team_members = []
-        if analysis.results and isinstance(analysis.results, dict):
-            team_analysis = analysis.results.get('team_analysis', {})
-            members = team_analysis.get('members', [])
-            team_members = [member.get('user_email', '').lower() for member in members if member.get('user_email')]
+        survey_responses = []
+        if team_members:
+            raw_responses = db.query(UserBurnoutReport).filter(
+                or_(
+                    UserBurnoutReport.analysis_id == analysis_id,
+                    (
+                        func.lower(UserBurnoutReport.email).in_(team_members) &
+                        (UserBurnoutReport.submitted_at >= today_start)
+                    )
+                )
+            ).order_by(
+                UserBurnoutReport.email.asc(),
+                UserBurnoutReport.submitted_at.desc()
+            ).all()
+
+            responses_by_email = {}
+            for response in raw_responses:
+                normalized_email = normalize_survey_email(response.email)
+                if normalized_email and normalized_email not in responses_by_email:
+                    responses_by_email[normalized_email] = response
+            survey_responses = list(responses_by_email.values())
 
         # Calculate response statistics
         total_members = len(team_members)
@@ -1887,7 +1930,7 @@ async def get_team_survey_status(
 
         # Identify non-responders (use email from survey response directly)
         responded_emails = {
-            response.email.lower()
+            normalize_survey_email(response.email)
             for response in survey_responses
             if response.email
         }

--- a/backend/app/models/slack_workspace_mapping.py
+++ b/backend/app/models/slack_workspace_mapping.py
@@ -1,7 +1,7 @@
 """
 Slack workspace mapping model for correlating Slack workspaces to organizations.
 """
-from sqlalchemy import Column, Index, Integer, String, DateTime, ForeignKey, UniqueConstraint, Boolean
+from sqlalchemy import Column, Index, Integer, String, DateTime, ForeignKey, UniqueConstraint, Boolean, JSON
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 from .base import Base
@@ -34,6 +34,7 @@ class SlackWorkspaceMapping(Base):
 
     # Feature flags - what capabilities are enabled for this workspace
     survey_enabled = Column(Boolean, default=False)  # Slash command surveys via /burnout
+    survey_recipients = Column(JSON, nullable=True)  # Org-wide selected UserCorrelation IDs for scheduled surveys
     granted_scopes = Column(String(500), nullable=True)  # Comma-separated list of OAuth scopes
 
     # Relationships
@@ -58,6 +59,7 @@ class SlackWorkspaceMapping(Base):
             'registered_at': self.registered_at.isoformat() if self.registered_at else None,
             'status': self.status,
             'survey_enabled': self.survey_enabled,
+            'survey_recipients': self.survey_recipients,
             'granted_scopes': self.granted_scopes
         }
 

--- a/backend/app/services/survey_recipient_service.py
+++ b/backend/app/services/survey_recipient_service.py
@@ -1,0 +1,109 @@
+"""
+Helpers for automated survey recipient selection.
+
+Scheduled Slack surveys run at the organization level, so the selected
+recipient list needs an organization-scoped source of truth.
+"""
+from typing import Optional
+import logging
+
+from sqlalchemy.orm import Session
+
+from ..models.rootly_integration import RootlyIntegration
+from ..models.slack_workspace_mapping import SlackWorkspaceMapping
+from ..models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+def get_active_workspace_mapping_for_org(
+    db: Session,
+    organization_id: Optional[int]
+) -> Optional[SlackWorkspaceMapping]:
+    """Return the most recently registered active Slack workspace for an org."""
+    if not organization_id:
+        return None
+
+    return (
+        db.query(SlackWorkspaceMapping)
+        .filter(
+            SlackWorkspaceMapping.organization_id == organization_id,
+            SlackWorkspaceMapping.status == "active"
+        )
+        .order_by(
+            SlackWorkspaceMapping.registered_at.desc(),
+            SlackWorkspaceMapping.id.desc()
+        )
+        .first()
+    )
+
+
+def get_saved_recipient_ids_for_org(
+    db: Session,
+    organization_id: Optional[int]
+) -> Optional[set[int]]:
+    """
+    Load the saved automated-survey recipients for an organization.
+
+    New selections are stored on the active Slack workspace mapping. We keep a
+    fallback to legacy Rootly integration rows so existing selections continue
+    to work until every org saves through the new path.
+    """
+    if not organization_id:
+        return None
+
+    workspace_mapping = get_active_workspace_mapping_for_org(db, organization_id)
+    if workspace_mapping and workspace_mapping.survey_recipients is not None:
+        recipient_ids = workspace_mapping.survey_recipients or []
+        return set(recipient_ids) if recipient_ids else None
+
+    integrations = (
+        db.query(RootlyIntegration)
+        .join(User, User.id == RootlyIntegration.user_id)
+        .filter(
+            User.organization_id == organization_id,
+            RootlyIntegration.platform == "rootly",
+            RootlyIntegration.is_active == True,
+            RootlyIntegration.survey_recipients.isnot(None)
+        )
+        .order_by(
+            RootlyIntegration.last_synced_at.desc().nullslast(),
+            RootlyIntegration.last_used_at.desc().nullslast(),
+            RootlyIntegration.created_at.desc(),
+            RootlyIntegration.id.desc()
+        )
+        .all()
+    )
+
+    if not integrations:
+        return None
+
+    if len(integrations) > 1:
+        logger.info(
+            "Found %s legacy integrations with saved survey recipients for org %s; using integration %s",
+            len(integrations),
+            organization_id,
+            integrations[0].id,
+        )
+
+    recipient_ids = integrations[0].survey_recipients or []
+    return set(recipient_ids) if recipient_ids else None
+
+
+def save_survey_recipient_ids_for_org(
+    db: Session,
+    organization_id: Optional[int],
+    recipient_ids: Optional[list[int]]
+) -> Optional[SlackWorkspaceMapping]:
+    """
+    Persist the organization-wide automated-survey recipient selection.
+
+    Passing ``None`` resets back to the default behavior of sending to all
+    eligible Slack-linked users.
+    """
+    workspace_mapping = get_active_workspace_mapping_for_org(db, organization_id)
+    if not workspace_mapping:
+        return None
+
+    workspace_mapping.survey_recipients = recipient_ids if recipient_ids else None
+    return workspace_mapping

--- a/backend/app/services/survey_response_service.py
+++ b/backend/app/services/survey_response_service.py
@@ -1,0 +1,50 @@
+"""
+Helpers for matching survey responses to members and time windows.
+"""
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+
+def normalize_survey_email(email: Optional[str]) -> str:
+    """Normalize survey email keys for dedupe/matching."""
+    return (email or "").strip().lower()
+
+
+def get_utc_day_bounds(reference: Optional[datetime] = None) -> tuple[datetime, datetime]:
+    """Return the UTC start/end bounds for the reference day."""
+    now = reference.astimezone(timezone.utc) if reference else datetime.now(timezone.utc)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + timedelta(days=1) - timedelta(microseconds=1)
+    return day_start, day_end
+
+
+def extract_analysis_member_emails(results: Optional[dict]) -> list[str]:
+    """
+    Extract normalized member emails from analysis results.
+
+    Surveys should apply only to analyses that actually include the member, so we
+    derive the email set from the analysis team roster instead of the whole org.
+    """
+    if not results or not isinstance(results, dict):
+        return []
+
+    team_analysis = results.get("team_analysis", {})
+    if isinstance(team_analysis, dict):
+        members = team_analysis.get("members", []) or []
+    elif isinstance(team_analysis, list):
+        members = team_analysis
+    else:
+        members = []
+
+    emails: list[str] = []
+    seen: set[str] = set()
+
+    for member in members:
+        if not isinstance(member, dict):
+            continue
+        email = normalize_survey_email(member.get("user_email") or member.get("email"))
+        if email and email not in seen:
+            seen.add(email)
+            emails.append(email)
+
+    return emails

--- a/backend/app/services/survey_scheduler.py
+++ b/backend/app/services/survey_scheduler.py
@@ -22,6 +22,7 @@ from ..models import SessionLocal
 from ..core.distributed_lock import with_distributed_lock
 from .slack_dm_sender import SlackDMSender
 from .notification_service import NotificationService
+from .survey_recipient_service import get_saved_recipient_ids_for_org
 from .slack_token_service import get_slack_token_for_organization, SlackTokenService
 from ..utils import mask_email
 
@@ -261,48 +262,6 @@ class SurveyScheduler:
         reminders for an organization to avoid overlapping Slack DMs.
         """
         return f"survey_delivery:org:{organization_id}"
-
-    def _get_saved_recipient_ids_for_org(self, organization_id: int, db: Session) -> Optional[set[int]]:
-        """
-        Resolve the saved automated-survey recipient list for an organization.
-
-        Recipient selections are currently stored on RootlyIntegration rows, but
-        scheduled delivery runs at the organization level. We therefore pick the
-        most recently active integration in the org that actually has a saved
-        recipient list, instead of relying on an arbitrary org user.
-        """
-        from app.models.user import User
-        from app.models.rootly_integration import RootlyIntegration
-
-        integrations = (
-            db.query(RootlyIntegration)
-            .join(User, User.id == RootlyIntegration.user_id)
-            .filter(
-                User.organization_id == organization_id,
-                RootlyIntegration.platform == "rootly",
-                RootlyIntegration.is_active == True,
-                RootlyIntegration.survey_recipients.isnot(None)
-            )
-            .order_by(
-                RootlyIntegration.last_synced_at.desc().nullslast(),
-                RootlyIntegration.last_used_at.desc().nullslast(),
-                RootlyIntegration.created_at.desc(),
-                RootlyIntegration.id.desc()
-            )
-            .all()
-        )
-
-        if not integrations:
-            return None
-
-        if len(integrations) > 1:
-            logger.info(
-                f"Found {len(integrations)} active integrations with saved survey recipients "
-                f"for org {organization_id}; using integration {integrations[0].id}"
-            )
-
-        recipient_ids = integrations[0].survey_recipients or []
-        return set(recipient_ids) if recipient_ids else None
 
     async def _run_survey_job(self, organization_id: int, is_reminder: bool = False):
         """Open a fresh DB session for each scheduled survey job execution."""
@@ -794,7 +753,7 @@ class SurveyScheduler:
         saved_recipient_ids = None
 
         if apply_saved_recipients:
-            saved_recipient_ids = self._get_saved_recipient_ids_for_org(organization_id, db)
+            saved_recipient_ids = get_saved_recipient_ids_for_org(db, organization_id)
             if saved_recipient_ids is not None:
                 logger.info(f"Using saved recipient list for org {organization_id}: {len(saved_recipient_ids)} users selected")
             else:

--- a/backend/app/services/survey_scheduler.py
+++ b/backend/app/services/survey_scheduler.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Tuple, Optional
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy.orm import Session
-from sqlalchemy import and_
+from sqlalchemy import and_, func, or_
 import pytz
 
 from ..models.survey_schedule import SurveySchedule, UserSurveyPreference
@@ -23,6 +23,7 @@ from ..core.distributed_lock import with_distributed_lock
 from .slack_dm_sender import SlackDMSender
 from .notification_service import NotificationService
 from .survey_recipient_service import get_saved_recipient_ids_for_org
+from .survey_response_service import get_utc_day_bounds, normalize_survey_email
 from .slack_token_service import get_slack_token_for_organization, SlackTokenService
 from ..utils import mask_email
 
@@ -58,6 +59,62 @@ class SurveyScheduler:
             return datetime.now(tz).date()
         except Exception:
             return date.today()
+
+    def _get_recipient_delivery_lock_key(self, email: str) -> str:
+        """Build a cross-schedule lock key for one recipient."""
+        return f"survey_delivery:recipient:{normalize_survey_email(email)}"
+
+    def _has_survey_touchpoint_today(
+        self,
+        db: Session,
+        email: str,
+        day_start_utc: datetime,
+        day_end_utc: datetime,
+        exclude_organization_id: Optional[int] = None
+    ) -> bool:
+        """
+        Check whether a recipient already got a survey ping or submitted today.
+
+        This prevents duplicate scheduled DMs across overlapping org/account/token
+        paths while still letting one response count everywhere the member belongs.
+        Reminder paths can exclude the current org so a valid same-org reminder is
+        not blocked by that org's own initial send.
+        """
+        normalized_email = normalize_survey_email(email)
+        if not normalized_email:
+            return False
+
+        existing_report = db.query(UserBurnoutReport.id).filter(
+            func.lower(UserBurnoutReport.email) == normalized_email,
+            UserBurnoutReport.submitted_at >= day_start_utc,
+            UserBurnoutReport.submitted_at <= day_end_utc
+        ).first()
+        if existing_report:
+            return True
+
+        touchpoint_query = db.query(SurveyPeriod.id).filter(
+            func.lower(SurveyPeriod.email) == normalized_email
+        )
+        if exclude_organization_id is not None:
+            touchpoint_query = touchpoint_query.filter(
+                SurveyPeriod.organization_id != exclude_organization_id
+            )
+
+        existing_touchpoint = touchpoint_query.filter(
+            or_(
+                and_(
+                    SurveyPeriod.initial_sent_at.isnot(None),
+                    SurveyPeriod.initial_sent_at >= day_start_utc,
+                    SurveyPeriod.initial_sent_at <= day_end_utc
+                ),
+                and_(
+                    SurveyPeriod.last_reminder_sent_at.isnot(None),
+                    SurveyPeriod.last_reminder_sent_at >= day_start_utc,
+                    SurveyPeriod.last_reminder_sent_at <= day_end_utc
+                )
+            )
+        ).first()
+        return existing_touchpoint is not None
 
     def _calculate_period_bounds(
         self,
@@ -403,30 +460,60 @@ class SurveyScheduler:
                             if preference:
                                 if not preference.receive_daily_surveys or not preference.receive_reminders:
                                     continue
+                        normalized_email = normalize_survey_email(period.email)
+                        recipient_lock_key = self._get_recipient_delivery_lock_key(normalized_email)
+                        async with with_distributed_lock(
+                            recipient_lock_key,
+                            ttl_seconds=60,
+                            timeout_seconds=0.25
+                        ) as recipient_lock_acquired:
+                            if not recipient_lock_acquired:
+                                skipped_already_sent += 1
+                                logger.info(
+                                    "Skipping follow-up for %s - recipient already being processed elsewhere",
+                                    mask_email(normalized_email),
+                                )
+                                continue
 
-                        message = self._build_follow_up_message(schedule, period)
+                            if self._has_survey_touchpoint_today(
+                                db,
+                                normalized_email,
+                                today_start_utc,
+                                today_end_utc,
+                                exclude_organization_id=organization_id,
+                            ):
+                                skipped_already_sent += 1
+                                logger.debug(
+                                    "Skipping follow-up for %s - already contacted or responded today",
+                                    mask_email(normalized_email),
+                                )
+                                continue
 
-                        await self.dm_sender.send_survey_dm(
-                            slack_token=slack_token,
-                            slack_user_id=correlation.slack_user_id,
-                            user_id=period.user_id,
-                            organization_id=organization_id,
-                            message=message,
-                            user_email=correlation.email
-                        )
+                            message = self._build_follow_up_message(schedule, period)
 
-                        # Lock and update the period
-                        locked_period = db.query(SurveyPeriod).filter(
-                            SurveyPeriod.id == period.id
-                        ).with_for_update().first()
-                        if locked_period:
-                            locked_period.record_reminder_sent()
-                        sent_count += 1
+                            await self.dm_sender.send_survey_dm(
+                                slack_token=slack_token,
+                                slack_user_id=correlation.slack_user_id,
+                                user_id=period.user_id,
+                                organization_id=organization_id,
+                                message=message,
+                                user_email=normalized_email
+                            )
 
-                        logger.debug(f"Sent follow-up reminder #{period.reminder_count + 1} for period {period.id}")
+                            # Lock and update the period
+                            locked_period = db.query(SurveyPeriod).filter(
+                                SurveyPeriod.id == period.id
+                            ).with_for_update().first()
+                            if locked_period:
+                                locked_period.record_reminder_sent()
+                            db.commit()
+                            sent_count += 1
+
+                            logger.debug(f"Sent follow-up reminder #{period.reminder_count + 1} for period {period.id}")
 
                     except Exception as e:
                         logger.error(f"Failed to send follow-up for period {period.id}: {str(e)}")
+                        db.rollback()
                         failed_count += 1
 
                 db.commit()
@@ -631,6 +718,7 @@ class SurveyScheduler:
                 sent_count = 0
                 failed_count = 0
                 skipped_count = 0
+                today_start_utc, today_end_utc = get_utc_day_bounds()
 
                 for user in users:
                     try:
@@ -639,71 +727,101 @@ class SurveyScheduler:
                             skipped_count += 1
                             logger.warning(f"Skipping DM for {user.get('email')} - no User record found (user_id is None)")
                             continue
+                        normalized_email = normalize_survey_email(user.get('email'))
+                        if not normalized_email:
+                            skipped_count += 1
+                            logger.warning("Skipping DM for user with missing email")
+                            continue
 
-                        # If reminder, check if user already completed survey today
-                        # Check is scoped by user only - one survey per user per day regardless of org
-                        if is_reminder:
-                            today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
-
-                            already_completed = db.query(UserBurnoutReport).filter(
-                                UserBurnoutReport.user_id == user['user_id'],
-                                UserBurnoutReport.submitted_at >= today_start
-                            ).first()
-
-                            if already_completed:
+                        recipient_lock_key = self._get_recipient_delivery_lock_key(normalized_email)
+                        async with with_distributed_lock(
+                            recipient_lock_key,
+                            ttl_seconds=60,
+                            timeout_seconds=0.25
+                        ) as recipient_lock_acquired:
+                            if not recipient_lock_acquired:
                                 skipped_count += 1
-                                logger.debug(f"Skipping reminder for user {user['user_id']} - already completed")
+                                logger.info(
+                                    "Skipping %s delivery for %s - recipient already being processed elsewhere",
+                                    message_type,
+                                    mask_email(normalized_email),
+                                )
                                 continue
 
-                        await self.dm_sender.send_survey_dm(
-                            slack_token=slack_token,
-                            slack_user_id=user['slack_user_id'],
-                            user_id=user['user_id'],
-                            organization_id=organization_id,
-                            message=message_template,
-                            user_email=user['email']
-                        )
-                        sent_count += 1
+                            if self._has_survey_touchpoint_today(db, normalized_email, today_start_utc, today_end_utc):
+                                skipped_count += 1
+                                logger.debug(
+                                    "Skipping %s delivery for %s - already contacted or responded today",
+                                    message_type,
+                                    mask_email(normalized_email),
+                                )
+                                continue
 
-                        # Create notification for the user who received the survey
-                        try:
-                            notification_service = NotificationService(db)
-                            notification_service.create_survey_received_notification(
+                            # If reminder, check if user already completed survey today
+                            # Check is scoped by user only - one survey per user per day regardless of org
+                            if is_reminder:
+                                already_completed = db.query(UserBurnoutReport).filter(
+                                    UserBurnoutReport.user_id == user['user_id'],
+                                    UserBurnoutReport.submitted_at >= today_start_utc
+                                ).first()
+
+                                if already_completed:
+                                    skipped_count += 1
+                                    logger.debug(f"Skipping reminder for user {user['user_id']} - already completed")
+                                    continue
+
+                            await self.dm_sender.send_survey_dm(
+                                slack_token=slack_token,
+                                slack_user_id=user['slack_user_id'],
                                 user_id=user['user_id'],
                                 organization_id=organization_id,
-                                is_reminder=is_reminder,
-                                commit=False
+                                message=message_template,
+                                user_email=normalized_email
                             )
-                        except Exception as notif_error:
-                            logger.error(f"Failed to create notification for user {user['user_id']}: {str(notif_error)}")
+                            sent_count += 1
 
-                        # Create survey period for follow-up tracking (only for initial sends)
-                        if not is_reminder and schedule and user.get('correlation'):
+                            # Create notification for the user who received the survey
                             try:
-                                frequency_type = schedule.frequency_type or 'weekday'
-                                period_start, period_end = self._calculate_period_bounds(
-                                    frequency_type,
-                                    self._get_org_date(org_timezone),
-                                    schedule.day_of_week
-                                )
-
-                                self._create_or_update_survey_period(
-                                    db=db,
-                                    organization_id=organization_id,
-                                    user_correlation=user['correlation'],
+                                notification_service = NotificationService(db)
+                                notification_service.create_survey_received_notification(
                                     user_id=user['user_id'],
-                                    email=user['email'],
-                                    frequency_type=frequency_type,
-                                    period_start=period_start,
-                                    period_end=period_end,
-                                    sent_at=datetime.now(timezone.utc),
-                                    org_timezone=org_timezone
+                                    organization_id=organization_id,
+                                    is_reminder=is_reminder,
+                                    commit=False
                                 )
-                            except Exception as period_error:
-                                logger.error(f"Failed to create survey period: {str(period_error)}")
+                            except Exception as notif_error:
+                                logger.error(f"Failed to create notification for user {user['user_id']}: {str(notif_error)}")
+
+                            # Create survey period for follow-up tracking (only for initial sends)
+                            if not is_reminder and schedule and user.get('correlation'):
+                                try:
+                                    frequency_type = schedule.frequency_type or 'weekday'
+                                    period_start, period_end = self._calculate_period_bounds(
+                                        frequency_type,
+                                        self._get_org_date(org_timezone),
+                                        schedule.day_of_week
+                                    )
+
+                                    self._create_or_update_survey_period(
+                                        db=db,
+                                        organization_id=organization_id,
+                                        user_correlation=user['correlation'],
+                                        user_id=user['user_id'],
+                                        email=normalized_email,
+                                        frequency_type=frequency_type,
+                                        period_start=period_start,
+                                        period_end=period_end,
+                                        sent_at=datetime.now(timezone.utc),
+                                        org_timezone=org_timezone
+                                    )
+                                except Exception as period_error:
+                                    logger.error(f"Failed to create survey period: {str(period_error)}")
+
+                            db.commit()
 
                     except Exception as e:
                         logger.error(f"Failed to send DM to user {user['user_id']}: {str(e)}")
+                        db.rollback()
                         failed_count += 1
 
                 if is_reminder:
@@ -790,8 +908,13 @@ class SurveyScheduler:
                 )
                 continue
 
+            normalized_email = normalize_survey_email(correlation.email)
+            if not normalized_email:
+                logger.warning("Skipping correlation %s - missing email", correlation.id)
+                continue
+
             # Skip if we already processed this email (keep most recent correlation)
-            if correlation.email in recipients_dict:
+            if normalized_email in recipients_dict:
                 logger.debug(f"Duplicate email {correlation.email}, keeping first correlation (most recent)")
                 continue
 
@@ -810,10 +933,10 @@ class SurveyScheduler:
             if is_reminder and user and preference and not preference.receive_reminders:
                 continue
 
-            recipients_dict[correlation.email] = {
+            recipients_dict[normalized_email] = {
                 'user_id': user.id if user else None,
                 'slack_user_id': correlation.slack_user_id,
-                'email': correlation.email,
+                'email': normalized_email,
                 'name': (user.name if user else None) or correlation.name,
                 'correlation': correlation
             }

--- a/backend/migrations/2026_03_13_add_survey_recipients_to_slack_workspace_mappings.sql
+++ b/backend/migrations/2026_03_13_add_survey_recipients_to_slack_workspace_mappings.sql
@@ -1,0 +1,28 @@
+-- Migration: Add org-level survey recipient storage to Slack workspace mappings
+-- This makes the Team Members checkbox selection the single source of truth for
+-- scheduled Slack surveys, while backfilling from legacy Rootly integration rows.
+
+ALTER TABLE slack_workspace_mappings
+ADD COLUMN IF NOT EXISTS survey_recipients JSON;
+
+COMMENT ON COLUMN slack_workspace_mappings.survey_recipients IS
+'Organization-wide selected UserCorrelation IDs for scheduled Slack surveys';
+
+UPDATE slack_workspace_mappings swm
+SET survey_recipients = (
+    SELECT ri.survey_recipients
+    FROM rootly_integrations ri
+    JOIN users u ON u.id = ri.user_id
+    WHERE u.organization_id = swm.organization_id
+      AND ri.platform = 'rootly'
+      AND ri.is_active = TRUE
+      AND ri.survey_recipients IS NOT NULL
+    ORDER BY
+      ri.last_synced_at DESC NULLS LAST,
+      ri.last_used_at DESC NULLS LAST,
+      ri.created_at DESC,
+      ri.id DESC
+    LIMIT 1
+)
+WHERE swm.organization_id IS NOT NULL
+  AND swm.survey_recipients IS NULL;

--- a/backend/migrations/migration_runner.py
+++ b/backend/migrations/migration_runner.py
@@ -1333,10 +1333,16 @@ class MigrationRunner:
                     """
                 ]
             },
-          {
+            {
                 "name": "046_add_team_scoped_key_to_rootly_integrations",
                 "description": "Add key_type and team_name columns to rootly_integrations for team-scoped API key support",
-                "sql_file": "2026_02_24_add_team_scoped_key_to_rootly_integrations.sql"},
+                "sql_file": "2026_02_24_add_team_scoped_key_to_rootly_integrations.sql"
+            },
+            {
+                "name": "050_add_survey_recipients_to_slack_workspace_mappings",
+                "description": "Store scheduled Slack survey recipients on the org's active Slack workspace mapping",
+                "sql_file": "2026_03_13_add_survey_recipients_to_slack_workspace_mappings.sql"
+            },
             # Add future migrations here with incrementing numbers
         ]
 

--- a/backend/tests/test_survey_recipient_service.py
+++ b/backend/tests/test_survey_recipient_service.py
@@ -1,0 +1,70 @@
+"""Tests for org-level automated survey recipient selection."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from backend.app.services.survey_recipient_service import (
+    get_saved_recipient_ids_for_org,
+    save_survey_recipient_ids_for_org,
+)
+
+
+def _make_query(*, first=None, all_rows=None):
+    query = MagicMock()
+    query.filter.return_value = query
+    query.order_by.return_value = query
+    query.join.return_value = query
+    query.first.return_value = first
+    query.all.return_value = all_rows or []
+    return query
+
+
+class TestSurveyRecipientService(unittest.TestCase):
+    def test_get_saved_recipient_ids_prefers_workspace_mapping(self):
+        db = MagicMock()
+        workspace_mapping = SimpleNamespace(survey_recipients=[11, 22])
+        db.query.return_value = _make_query(first=workspace_mapping)
+
+        recipient_ids = get_saved_recipient_ids_for_org(db, 7)
+
+        self.assertEqual(recipient_ids, {11, 22})
+        self.assertEqual(db.query.call_count, 1)
+
+    def test_get_saved_recipient_ids_falls_back_to_legacy_integration(self):
+        db = MagicMock()
+        workspace_mapping = SimpleNamespace(survey_recipients=None)
+        legacy_integration = SimpleNamespace(id=91, survey_recipients=[3, 5, 8])
+        db.query.side_effect = [
+            _make_query(first=workspace_mapping),
+            _make_query(all_rows=[legacy_integration]),
+        ]
+
+        recipient_ids = get_saved_recipient_ids_for_org(db, 7)
+
+        self.assertEqual(recipient_ids, {3, 5, 8})
+        self.assertEqual(db.query.call_count, 2)
+
+    def test_save_survey_recipient_ids_updates_workspace_mapping(self):
+        db = MagicMock()
+        workspace_mapping = SimpleNamespace(survey_recipients=None)
+        db.query.return_value = _make_query(first=workspace_mapping)
+
+        saved_mapping = save_survey_recipient_ids_for_org(db, 7, [1, 2, 3])
+
+        self.assertIs(saved_mapping, workspace_mapping)
+        self.assertEqual(workspace_mapping.survey_recipients, [1, 2, 3])
+
+    def test_save_survey_recipient_ids_clears_workspace_mapping_when_reset(self):
+        db = MagicMock()
+        workspace_mapping = SimpleNamespace(survey_recipients=[1, 2, 3])
+        db.query.return_value = _make_query(first=workspace_mapping)
+
+        saved_mapping = save_survey_recipient_ids_for_org(db, 7, None)
+
+        self.assertIs(saved_mapping, workspace_mapping)
+        self.assertIsNone(workspace_mapping.survey_recipients)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_survey_response_service.py
+++ b/backend/tests/test_survey_response_service.py
@@ -1,0 +1,73 @@
+"""Tests for shared survey response helpers."""
+
+import importlib.util
+import os
+import unittest
+from datetime import datetime, timezone
+
+MODULE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "app",
+    "services",
+    "survey_response_service.py",
+)
+MODULE_SPEC = importlib.util.spec_from_file_location("survey_response_service", MODULE_PATH)
+assert MODULE_SPEC and MODULE_SPEC.loader
+survey_response_service = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(survey_response_service)
+
+extract_analysis_member_emails = survey_response_service.extract_analysis_member_emails
+get_utc_day_bounds = survey_response_service.get_utc_day_bounds
+normalize_survey_email = survey_response_service.normalize_survey_email
+
+
+class TestSurveyResponseService(unittest.TestCase):
+    def test_normalize_survey_email(self):
+        self.assertEqual(normalize_survey_email("  Alice@Example.com "), "alice@example.com")
+        self.assertEqual(normalize_survey_email(None), "")
+
+    def test_get_utc_day_bounds_uses_reference_day(self):
+        reference = datetime(2026, 3, 13, 22, 30, tzinfo=timezone.utc)
+        day_start, day_end = get_utc_day_bounds(reference)
+
+        self.assertEqual(day_start.isoformat(), "2026-03-13T00:00:00+00:00")
+        self.assertEqual(day_end.isoformat(), "2026-03-13T23:59:59.999999+00:00")
+
+    def test_extract_analysis_member_emails_from_dict_team_analysis(self):
+        results = {
+            "team_analysis": {
+                "members": [
+                    {"user_email": "ALICE@example.com"},
+                    {"email": "bob@example.com"},
+                    {"user_email": "alice@example.com"},
+                    {"user_email": ""},
+                ]
+            }
+        }
+
+        self.assertEqual(
+            extract_analysis_member_emails(results),
+            ["alice@example.com", "bob@example.com"],
+        )
+
+    def test_extract_analysis_member_emails_from_list_team_analysis(self):
+        results = {
+            "team_analysis": [
+                {"user_email": "carol@example.com"},
+                {"user_email": "dave@example.com"},
+            ]
+        }
+
+        self.assertEqual(
+            extract_analysis_member_emails(results),
+            ["carol@example.com", "dave@example.com"],
+        )
+
+    def test_extract_analysis_member_emails_returns_empty_for_missing_results(self):
+        self.assertEqual(extract_analysis_member_emails(None), [])
+        self.assertEqual(extract_analysis_member_emails({}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -588,6 +588,9 @@ export function SlackSurveyTabs({
                 <p className="text-xs text-neutral-500 mt-1">
                   Send surveys every weekday at a specific time
                 </p>
+                <p className="text-xs text-neutral-500 mt-1">
+                  This schedule is shared across your org and appears the same under any connected token.
+                </p>
                 {scheduleEnabled && (
                   <p className="text-xs font-medium text-purple-600 mt-1.5">
                     {Math.max(0, selectedRecipients.size)} {selectedRecipients.size === 1 ? 'user' : 'users'} selected

--- a/frontend/src/components/SlackSurveyTabs.tsx
+++ b/frontend/src/components/SlackSurveyTabs.tsx
@@ -386,6 +386,9 @@ export function SlackSurveyTabs({
             <p className="text-sm text-neutral-700 mb-3">
               Select which team members should receive automated survey DMs. Only users with Slack accounts can be selected.
             </p>
+            <p className="text-xs text-neutral-500">
+              This recipient list is shared across admins and is the same list used for scheduled Slack surveys.
+            </p>
           </div>
 
           {/* Synced Users List with Checkboxes */}


### PR DESCRIPTION
## Summary
- make scheduled Slack survey configuration and recipient selection behave as org-wide state across connected tokens
- dedupe scheduled survey and follow-up delivery by normalized email across overlapping org/account/token paths
- apply one member survey response to any analysis roster that includes that member

## Testing
- python3 -m py_compile backend/app/services/survey_response_service.py backend/app/services/survey_scheduler.py backend/app/api/endpoints/analyses.py backend/app/api/endpoints/slack.py backend/tests/test_survey_response_service.py
- python3 -m unittest backend.tests.test_survey_response_service