### PR TITLE
fix: sync selected org across integrations and management

### DIFF
--- a/frontend/src/app/auth/success/page.tsx
+++ b/frontend/src/app/auth/success/page.tsx
@@ -51,6 +51,7 @@ export default function AuthSuccessPage() {
           if (key && (
             key.includes('integrations') ||
             key.includes('selected_organization') ||
+            key === 'selectedOrganization' ||
             key.includes('analyses') ||
             key.includes('user_') ||
             key.includes('github_') ||

--- a/frontend/src/app/integrations/handlers/integration-handlers.ts
+++ b/frontend/src/app/integrations/handlers/integration-handlers.ts
@@ -1,5 +1,9 @@
 import { toast } from "sonner"
 import { type Integration, API_BASE } from "../types"
+import {
+  getStoredSelectedOrganization,
+  setStoredSelectedOrganization,
+} from "@/lib/selected-organization"
 
 /**
  * Test connection to Rootly or PagerDuty with API token
@@ -434,7 +438,7 @@ export async function addIntegration(
           (platform === 'rootly' ? firstCreatedIntegrationId : null)
         if (newIntegrationId) {
           const integrationIdStr = newIntegrationId.toString()
-          localStorage.setItem('selected_organization', integrationIdStr)
+          setStoredSelectedOrganization(integrationIdStr)
           // Update React state to reflect the selection in UI
           if (setSelectedOrganization) {
             setSelectedOrganization(integrationIdStr)
@@ -559,9 +563,9 @@ export async function deleteIntegration(
       }
 
       // If we deleted the currently selected integration, clear the selection
-      const selectedOrg = localStorage.getItem('selected_organization')
+      const selectedOrg = getStoredSelectedOrganization()
       if (selectedOrg === integrationIdStr) {
-        localStorage.removeItem('selected_organization')
+        setStoredSelectedOrganization(null)
         // Clear React state to trigger auto-select
         if (setSelectedOrganization) {
           setSelectedOrganization("")

--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -97,6 +97,11 @@ import Link from "next/link"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
+import {
+  getStoredSelectedOrganization,
+  setStoredSelectedOrganization,
+  subscribeToSelectedOrganization,
+} from "@/lib/selected-organization"
 import { MappingDrawer } from "@/components/mapping-drawer"
 import { NotificationDrawer } from "@/components/notifications"
 import ManualSurveyDeliveryModal from "@/components/ManualSurveyDeliveryModal"
@@ -779,7 +784,7 @@ export default function IntegrationsPage() {
     loadLlmConfig() // Load AI config to persist connection state
 
     // Load saved organization preference
-    const savedOrg = localStorage.getItem('selected_organization')
+    const savedOrg = getStoredSelectedOrganization()
     // Accept both numeric IDs and beta string IDs (like "beta-rootly")
     if (savedOrg) {
       setSelectedOrganization(savedOrg)
@@ -867,6 +872,13 @@ export default function IntegrationsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  useEffect(() => {
+    return subscribeToSelectedOrganization((value) => {
+      if (!value) return
+      setSelectedOrganization((current) => (current === value ? current : value))
+    })
+  }, [])
+
   // Load Slack permissions when integration is available
   useEffect(() => {
     if (slackIntegration && activeEnhancementTab === 'slack') {
@@ -912,7 +924,7 @@ export default function IntegrationsPage() {
       const firstIntegration = integrations[0]
       const firstIntegrationId = firstIntegration.id.toString()
       setSelectedOrganization(firstIntegrationId)
-      localStorage.setItem('selected_organization', firstIntegrationId)
+      setStoredSelectedOrganization(firstIntegrationId)
 
       // Show sync modal after auto-selecting (same as manual switch)
       setTimeout(() => {
@@ -2566,7 +2578,7 @@ export default function IntegrationsPage() {
                       onValueChange={async (value) => {
                         // Update state immediately for instant UI response
                         setSelectedOrganization(value)
-                        localStorage.setItem('selected_organization', value)
+                        setStoredSelectedOrganization(value)
 
                         // Only show toast and check permissions if selecting a different organization
                         if (value !== selectedOrganization) {

--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -875,9 +875,10 @@ export default function IntegrationsPage() {
   useEffect(() => {
     return subscribeToSelectedOrganization((value) => {
       if (!value) return
+      if (!integrations.some((integration) => integration.id.toString() === value)) return
       setSelectedOrganization((current) => (current === value ? current : value))
     })
-  }, [])
+  }, [integrations])
 
   // Load Slack permissions when integration is available
   useEffect(() => {

--- a/frontend/src/app/management/page.tsx
+++ b/frontend/src/app/management/page.tsx
@@ -43,6 +43,11 @@ import { UserMappingDrawer } from "./components/UserMappingDrawer"
 import { OrganizationManagementDialog } from "@/app/integrations/dialogs/OrganizationManagementDialog"
 import * as OrganizationHandlers from "@/app/integrations/handlers/organization-handlers"
 import {
+  getStoredSelectedOrganization,
+  setStoredSelectedOrganization,
+  subscribeToSelectedOrganization,
+} from "@/lib/selected-organization"
+import {
   fetchGithubUsers,
   fetchJiraUsers,
   fetchLinearUsers,
@@ -203,7 +208,7 @@ function TeamPageContent() {
 
         // Restore selected org, with validation against actual integration IDs
         const urlOrgId = searchParams.get("org")
-        const saved = localStorage.getItem("selectedOrganization")
+        const saved = getStoredSelectedOrganization()
         const matchesIntegration = (id: string) => allIntegrations.some(i => i.id.toString() === id)
 
         if (urlOrgId && matchesIntegration(urlOrgId)) {
@@ -222,6 +227,13 @@ function TeamPageContent() {
 
     fetchIntegrations()
   }, [searchParams])
+
+  useEffect(() => {
+    return subscribeToSelectedOrganization((value) => {
+      if (!value) return
+      setSelectedOrganization((current) => (current === value ? current : value))
+    })
+  }, [])
 
   // Handle view parameter from URL
   useEffect(() => {
@@ -275,7 +287,7 @@ function TeamPageContent() {
   // Save selected organization to localStorage
   useEffect(() => {
     if (selectedOrganization) {
-      localStorage.setItem("selectedOrganization", selectedOrganization)
+      setStoredSelectedOrganization(selectedOrganization)
     }
   }, [selectedOrganization])
 

--- a/frontend/src/app/management/page.tsx
+++ b/frontend/src/app/management/page.tsx
@@ -211,12 +211,19 @@ function TeamPageContent() {
         const saved = getStoredSelectedOrganization()
         const matchesIntegration = (id: string) => allIntegrations.some(i => i.id.toString() === id)
 
+        let nextSelectedOrganization: string | null = null
+
         if (urlOrgId && matchesIntegration(urlOrgId)) {
-          setSelectedOrganization(urlOrgId)
+          nextSelectedOrganization = urlOrgId
         } else if (saved && matchesIntegration(saved)) {
-          setSelectedOrganization(saved)
+          nextSelectedOrganization = saved
         } else if (allIntegrations.length > 0) {
-          setSelectedOrganization(allIntegrations[0].id.toString())
+          nextSelectedOrganization = allIntegrations[0].id.toString()
+        }
+
+        if (nextSelectedOrganization) {
+          setSelectedOrganization(nextSelectedOrganization)
+          setStoredSelectedOrganization(nextSelectedOrganization, { emit: false })
         }
       } catch (error) {
         console.error("Failed to load integrations:", error)
@@ -231,9 +238,10 @@ function TeamPageContent() {
   useEffect(() => {
     return subscribeToSelectedOrganization((value) => {
       if (!value) return
+      if (!integrations.some((integration) => integration.id.toString() === value)) return
       setSelectedOrganization((current) => (current === value ? current : value))
     })
-  }, [])
+  }, [integrations])
 
   // Handle view parameter from URL
   useEffect(() => {
@@ -283,13 +291,6 @@ function TeamPageContent() {
 
     fetchConnectedIntegrations()
   }, [])
-
-  // Save selected organization to localStorage
-  useEffect(() => {
-    if (selectedOrganization) {
-      setStoredSelectedOrganization(selectedOrganization)
-    }
-  }, [selectedOrganization])
 
   // Clear integration users data and reset pagination when organization changes
   useEffect(() => {
@@ -1074,7 +1075,10 @@ function TeamPageContent() {
                             <label className="text-sm font-medium text-neutral-900 mb-2 block">Select Organization</label>
                             <Select
                               value={selectedOrganization}
-                              onValueChange={setSelectedOrganization}
+                              onValueChange={(value) => {
+                                setSelectedOrganization(value)
+                                setStoredSelectedOrganization(value)
+                              }}
                               disabled={loadingIntegrations || !hasPrimaryIntegration}
                             >
                               <SelectTrigger className="w-full sm:w-72">

--- a/frontend/src/lib/selected-organization.ts
+++ b/frontend/src/lib/selected-organization.ts
@@ -1,0 +1,71 @@
+"use client"
+
+export const SELECTED_ORGANIZATION_STORAGE_KEY = "selected_organization"
+const LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY = "selectedOrganization"
+const SELECTED_ORGANIZATION_EVENT = "selected-organization-change"
+
+function writeSelectedOrganization(value: string | null) {
+  if (typeof window === "undefined") return
+
+  if (value) {
+    localStorage.setItem(SELECTED_ORGANIZATION_STORAGE_KEY, value)
+    localStorage.setItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY, value)
+  } else {
+    localStorage.removeItem(SELECTED_ORGANIZATION_STORAGE_KEY)
+    localStorage.removeItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
+  }
+}
+
+export function getStoredSelectedOrganization(): string | null {
+  if (typeof window === "undefined") return null
+
+  const value =
+    localStorage.getItem(SELECTED_ORGANIZATION_STORAGE_KEY) ||
+    localStorage.getItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
+
+  if (value) {
+    writeSelectedOrganization(value)
+  }
+
+  return value
+}
+
+export function setStoredSelectedOrganization(value: string | null) {
+  if (typeof window === "undefined") return
+
+  writeSelectedOrganization(value)
+  window.dispatchEvent(
+    new CustomEvent(SELECTED_ORGANIZATION_EVENT, {
+      detail: { value },
+    })
+  )
+}
+
+export function subscribeToSelectedOrganization(callback: (value: string | null) => void) {
+  if (typeof window === "undefined") {
+    return () => {}
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (
+      event.key === null ||
+      event.key === SELECTED_ORGANIZATION_STORAGE_KEY ||
+      event.key === LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY
+    ) {
+      callback(getStoredSelectedOrganization())
+    }
+  }
+
+  const handleCustomEvent = (event: Event) => {
+    const customEvent = event as CustomEvent<{ value?: string | null }>
+    callback(customEvent.detail?.value ?? getStoredSelectedOrganization())
+  }
+
+  window.addEventListener("storage", handleStorage)
+  window.addEventListener(SELECTED_ORGANIZATION_EVENT, handleCustomEvent)
+
+  return () => {
+    window.removeEventListener("storage", handleStorage)
+    window.removeEventListener(SELECTED_ORGANIZATION_EVENT, handleCustomEvent)
+  }
+}

--- a/frontend/src/lib/selected-organization.ts
+++ b/frontend/src/lib/selected-organization.ts
@@ -4,12 +4,41 @@ export const SELECTED_ORGANIZATION_STORAGE_KEY = "selected_organization"
 const LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY = "selectedOrganization"
 const SELECTED_ORGANIZATION_EVENT = "selected-organization-change"
 
+function safeGetItem(key: string) {
+  try {
+    return localStorage.getItem(key)
+  } catch (error) {
+    console.warn(`Failed to read localStorage key "${key}"`, error)
+    return null
+  }
+}
+
+function safeSetItem(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value)
+    return true
+  } catch (error) {
+    console.warn(`Failed to write localStorage key "${key}"`, error)
+    return false
+  }
+}
+
+function safeRemoveItem(key: string) {
+  try {
+    localStorage.removeItem(key)
+    return true
+  } catch (error) {
+    console.warn(`Failed to remove localStorage key "${key}"`, error)
+    return false
+  }
+}
+
 function readSelectedOrganization() {
   if (typeof window === "undefined") return null
 
   return (
-    localStorage.getItem(SELECTED_ORGANIZATION_STORAGE_KEY) ||
-    localStorage.getItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
+    safeGetItem(SELECTED_ORGANIZATION_STORAGE_KEY) ||
+    safeGetItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
   )
 }
 
@@ -17,12 +46,14 @@ function writeSelectedOrganization(value: string | null) {
   if (typeof window === "undefined") return
 
   if (value) {
-    localStorage.setItem(SELECTED_ORGANIZATION_STORAGE_KEY, value)
-    localStorage.setItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY, value)
-  } else {
-    localStorage.removeItem(SELECTED_ORGANIZATION_STORAGE_KEY)
-    localStorage.removeItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
+    const wrotePrimary = safeSetItem(SELECTED_ORGANIZATION_STORAGE_KEY, value)
+    const wroteLegacy = safeSetItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY, value)
+    return wrotePrimary && wroteLegacy
   }
+
+  const removedPrimary = safeRemoveItem(SELECTED_ORGANIZATION_STORAGE_KEY)
+  const removedLegacy = safeRemoveItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
+  return removedPrimary && removedLegacy
 }
 
 export function getStoredSelectedOrganization(): string | null {
@@ -35,8 +66,8 @@ export function setStoredSelectedOrganization(
 ) {
   if (typeof window === "undefined") return
 
-  const primaryValue = localStorage.getItem(SELECTED_ORGANIZATION_STORAGE_KEY)
-  const legacyValue = localStorage.getItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
+  const primaryValue = safeGetItem(SELECTED_ORGANIZATION_STORAGE_KEY)
+  const legacyValue = safeGetItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
   const currentValue = readSelectedOrganization()
   const valueChanged = currentValue !== value
   const storageAlreadySynced = value
@@ -47,9 +78,9 @@ export function setStoredSelectedOrganization(
     return
   }
 
-  writeSelectedOrganization(value)
+  const writeSucceeded = writeSelectedOrganization(value)
 
-  if (options.emit !== false && valueChanged) {
+  if (writeSucceeded && options.emit !== false && valueChanged) {
     window.dispatchEvent(
       new CustomEvent(SELECTED_ORGANIZATION_EVENT, {
         detail: { value },
@@ -63,13 +94,26 @@ export function subscribeToSelectedOrganization(callback: (value: string | null)
     return () => {}
   }
 
+  let pendingNotification: number | null = null
+
+  const notifyWithCurrentValue = () => {
+    if (pendingNotification !== null) {
+      window.clearTimeout(pendingNotification)
+    }
+
+    pendingNotification = window.setTimeout(() => {
+      pendingNotification = null
+      callback(getStoredSelectedOrganization())
+    }, 0)
+  }
+
   const handleStorage = (event: StorageEvent) => {
     if (
       event.key === null ||
       event.key === SELECTED_ORGANIZATION_STORAGE_KEY ||
       event.key === LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY
     ) {
-      callback(getStoredSelectedOrganization())
+      notifyWithCurrentValue()
     }
   }
 
@@ -82,6 +126,9 @@ export function subscribeToSelectedOrganization(callback: (value: string | null)
   window.addEventListener(SELECTED_ORGANIZATION_EVENT, handleCustomEvent)
 
   return () => {
+    if (pendingNotification !== null) {
+      window.clearTimeout(pendingNotification)
+    }
     window.removeEventListener("storage", handleStorage)
     window.removeEventListener(SELECTED_ORGANIZATION_EVENT, handleCustomEvent)
   }

--- a/frontend/src/lib/selected-organization.ts
+++ b/frontend/src/lib/selected-organization.ts
@@ -4,6 +4,15 @@ export const SELECTED_ORGANIZATION_STORAGE_KEY = "selected_organization"
 const LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY = "selectedOrganization"
 const SELECTED_ORGANIZATION_EVENT = "selected-organization-change"
 
+function readSelectedOrganization() {
+  if (typeof window === "undefined") return null
+
+  return (
+    localStorage.getItem(SELECTED_ORGANIZATION_STORAGE_KEY) ||
+    localStorage.getItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
+  )
+}
+
 function writeSelectedOrganization(value: string | null) {
   if (typeof window === "undefined") return
 
@@ -17,28 +26,36 @@ function writeSelectedOrganization(value: string | null) {
 }
 
 export function getStoredSelectedOrganization(): string | null {
-  if (typeof window === "undefined") return null
-
-  const value =
-    localStorage.getItem(SELECTED_ORGANIZATION_STORAGE_KEY) ||
-    localStorage.getItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
-
-  if (value) {
-    writeSelectedOrganization(value)
-  }
-
-  return value
+  return readSelectedOrganization()
 }
 
-export function setStoredSelectedOrganization(value: string | null) {
+export function setStoredSelectedOrganization(
+  value: string | null,
+  options: { emit?: boolean } = {}
+) {
   if (typeof window === "undefined") return
 
+  const primaryValue = localStorage.getItem(SELECTED_ORGANIZATION_STORAGE_KEY)
+  const legacyValue = localStorage.getItem(LEGACY_SELECTED_ORGANIZATION_STORAGE_KEY)
+  const currentValue = readSelectedOrganization()
+  const valueChanged = currentValue !== value
+  const storageAlreadySynced = value
+    ? primaryValue === value && legacyValue === value
+    : primaryValue === null && legacyValue === null
+
+  if (storageAlreadySynced) {
+    return
+  }
+
   writeSelectedOrganization(value)
-  window.dispatchEvent(
-    new CustomEvent(SELECTED_ORGANIZATION_EVENT, {
-      detail: { value },
-    })
-  )
+
+  if (options.emit !== false && valueChanged) {
+    window.dispatchEvent(
+      new CustomEvent(SELECTED_ORGANIZATION_EVENT, {
+        detail: { value },
+      })
+    )
+  }
 }
 
 export function subscribeToSelectedOrganization(callback: (value: string | null) => void) {


### PR DESCRIPTION
## Summary
- share selected organization state between integrations and management pages
- sync changes across both localStorage keys for backward compatibility
- propagate same-tab and cross-tab org changes immediately

## Testing
- npm install
- npm run type-check