### PR TITLE
refactor: streamline scoring contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/
+!frontend/src/lib/**
 lib64/
 parts/
 sdist/

--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -85,6 +85,8 @@ def extract_analysis_summary(full_results: dict) -> dict:
         health = full_results["team_health"]
         summary["team_health"] = {
             "overall_score": health.get("overall_score", 0),
+            "risk_score_100": health.get("risk_score_100", 0),
+            "health_score_100": health.get("health_score_100", 0),
             "members_at_risk": health.get("members_at_risk", 0)
         }
 
@@ -134,6 +136,9 @@ class AnalysisListResponse(BaseModel):
 class DailyTrendPoint(BaseModel):
     date: str
     overall_score: float
+    overall_score_semantics: Optional[str] = None
+    risk_score_100: Optional[float] = None
+    health_score_100: Optional[float] = None
     average_health_score: float
     members_at_risk: int
     total_members: int
@@ -1195,6 +1200,9 @@ async def regenerate_analysis_trends(
             daily_trends.append({
                 "date": current_date.strftime("%Y-%m-%d"),
                 "overall_score": round(daily_score, 2),
+                "overall_score_semantics": "health_10_compat",
+                "risk_score_100": round(max(0.0, min(100.0, 100.0 - (daily_score * 10))), 1),
+                "health_score_100": round(max(0.0, min(100.0, daily_score * 10)), 1),
                 "average_health_score": 0.0,  # Legacy analyses don't have this data
                 "incident_count": incidents_for_day,
                 "members_at_risk": members_at_risk,
@@ -1576,6 +1584,11 @@ async def get_historical_trends(
         
         # Get health status based on score
         overall_score = trend_data.get("overall_score", 0.0)
+        risk_score_100 = trend_data.get("risk_score_100")
+        health_score_100 = trend_data.get("health_score_100")
+        if risk_score_100 is None or health_score_100 is None:
+            health_score_100 = max(0.0, min(100.0, float(overall_score) * 10))
+            risk_score_100 = max(0.0, min(100.0, 100.0 - health_score_100))
         if overall_score <= 4.0:
             health_status = "critical"
         elif overall_score <= 6.5:
@@ -1588,6 +1601,9 @@ async def get_historical_trends(
         daily_trends.append(DailyTrendPoint(
             date=trend_date,
             overall_score=float(overall_score),
+            overall_score_semantics=trend_data.get("overall_score_semantics", "health_10_compat"),
+            risk_score_100=float(risk_score_100),
+            health_score_100=float(health_score_100),
             average_health_score=float(trend_data.get("average_health_score", 0.0)),  # Actual average from team health
             members_at_risk=int(members_at_risk),
             total_members=max(int(total_members), 1),  # Use actual total_members from analysis

--- a/backend/app/api/endpoints/analyses.py
+++ b/backend/app/api/endpoints/analyses.py
@@ -140,7 +140,6 @@ class DailyTrendPoint(BaseModel):
     overall_score_semantics: Optional[str] = None
     risk_score_100: Optional[float] = None
     health_score_100: Optional[float] = None
-    average_health_score: float
     members_at_risk: int
     total_members: int
     health_status: str
@@ -1204,7 +1203,6 @@ async def regenerate_analysis_trends(
                 "overall_score_semantics": "health_10_compat",
                 "risk_score_100": round(max(0.0, min(100.0, 100.0 - (daily_score * 10))), 1),
                 "health_score_100": round(max(0.0, min(100.0, daily_score * 10)), 1),
-                "average_health_score": 0.0,  # Legacy analyses don't have this data
                 "incident_count": incidents_for_day,
                 "members_at_risk": members_at_risk,
                 "total_members": total_members,
@@ -1605,7 +1603,6 @@ async def get_historical_trends(
             overall_score_semantics=trend_data.get("overall_score_semantics", "health_10_compat"),
             risk_score_100=float(risk_score_100),
             health_score_100=float(health_score_100),
-            average_health_score=float(trend_data.get("average_health_score", 0.0)),  # Actual average from team health
             members_at_risk=int(members_at_risk),
             total_members=max(int(total_members), 1),  # Use actual total_members from analysis
             health_status=health_status,
@@ -1828,7 +1825,6 @@ class DailyIncidentTrendPoint(BaseModel):
     members_at_risk: int
     total_members: int
     health_status: str
-    health_percentage: float
 
 
 class DailyIncidentTrendsResponse(BaseModel):
@@ -1899,8 +1895,7 @@ async def get_analysis_daily_trends(
             users_involved=trend.get("users_involved", 0),
             members_at_risk=trend.get("members_at_risk", 0),
             total_members=trend.get("total_members", 0),
-            health_status=trend.get("health_status", "unknown"),
-            health_percentage=trend.get("health_percentage", trend["overall_score"] * 10)
+            health_status=trend.get("health_status", "unknown")
         ))
     
     # Calculate summary statistics
@@ -2914,10 +2909,7 @@ async def get_member_daily_health(
             "summary": {
                 "total_days": len(daily_health_scores),
                 "days_with_data": len(days_with_data),
-                "days_without_data": len(days_without_data),
-                "avg_health_score": round(sum(d["health_score"] for d in days_with_data) / len(days_with_data)) if days_with_data else 0,
-                "lowest_health_day": min(days_with_data, key=lambda x: x["health_score"]) if days_with_data else None,
-                "highest_health_day": max(days_with_data, key=lambda x: x["health_score"]) if days_with_data else None
+                "days_without_data": len(days_without_data)
             }
         }
     }

--- a/backend/app/core/och_config.py
+++ b/backend/app/core/och_config.py
@@ -123,44 +123,12 @@ def calculate_personal_burnout(metrics: Dict[str, float], config: OCHConfig = No
     if config is None:
         config = OCHConfig()
 
-    factors = config.PERSONAL_BURNOUT_FACTORS
-    component_scores = {}
-    weighted_sum = 0.0
-    total_weight = 0.0
-
-    for factor_name, factor_config in factors.items():
-        if factor_name in metrics:
-            raw_value = max(0.0, metrics[factor_name])  # Ensure non-negative
-
-            # Calculate score with reasonable cap (allow 150% for extreme cases)
-            normalized_score = min(150.0, (raw_value / factor_config['scale_max']) * 100.0)
-
-            # Apply weight
-            weighted_score = normalized_score * factor_config['weight']
-            component_scores[factor_name] = {
-                'raw_value': raw_value,
-                'normalized_score': round(normalized_score, 2),
-                'weighted_score': round(weighted_score, 2),
-                'weight': factor_config['weight'],
-                'description': factor_config['description']
-            }
-
-            weighted_sum += weighted_score
-            total_weight += factor_config['weight']
-
-    # Calculate final score
-    if total_weight > 0:
-        final_score = weighted_sum / total_weight
-    else:
-        final_score = 0.0
-
-    return {
-        'score': round(final_score, 2),
-        'components': component_scores,
-        'dimension': OCHDimension.PERSONAL.value,
-        'interpretation': get_och_interpretation(final_score, config),
-        'data_completeness': total_weight
-    }
+    return _calculate_dimension_score(
+        metrics=metrics,
+        factors=config.PERSONAL_BURNOUT_FACTORS,
+        dimension=OCHDimension.PERSONAL,
+        config=config,
+    )
 
 
 def calculate_work_related_burnout(metrics: Dict[str, float], config: OCHConfig = None) -> Dict[str, Any]:
@@ -177,41 +145,50 @@ def calculate_work_related_burnout(metrics: Dict[str, float], config: OCHConfig 
     if config is None:
         config = OCHConfig()
 
-    factors = config.WORK_RELATED_BURNOUT_FACTORS
+    return _calculate_dimension_score(
+        metrics=metrics,
+        factors=config.WORK_RELATED_BURNOUT_FACTORS,
+        dimension=OCHDimension.WORK_RELATED,
+        config=config,
+    )
+
+
+def _calculate_dimension_score(
+    metrics: Dict[str, float],
+    factors: Dict[str, Dict[str, Any]],
+    dimension: OCHDimension,
+    config: OCHConfig,
+) -> Dict[str, Any]:
+    """Shared scorer for personal and work-related OCH dimensions."""
     component_scores = {}
     weighted_sum = 0.0
     total_weight = 0.0
 
     for factor_name, factor_config in factors.items():
-        if factor_name in metrics:
-            raw_value = max(0.0, metrics[factor_name])  # Ensure non-negative
+        if factor_name not in metrics:
+            continue
 
-            # Calculate score with reasonable cap (allow 150% for extreme cases)
-            normalized_score = min(150.0, (raw_value / factor_config['scale_max']) * 100.0)
+        raw_value = max(0.0, metrics[factor_name])
+        normalized_score = min(150.0, (raw_value / factor_config['scale_max']) * 100.0)
+        weighted_score = normalized_score * factor_config['weight']
 
-            # Apply weight
-            weighted_score = normalized_score * factor_config['weight']
-            component_scores[factor_name] = {
-                'raw_value': raw_value,
-                'normalized_score': round(normalized_score, 2),
-                'weighted_score': round(weighted_score, 2),
-                'weight': factor_config['weight'],
-                'description': factor_config['description']
-            }
+        component_scores[factor_name] = {
+            'raw_value': raw_value,
+            'normalized_score': round(normalized_score, 2),
+            'weighted_score': round(weighted_score, 2),
+            'weight': factor_config['weight'],
+            'description': factor_config['description']
+        }
 
-            weighted_sum += weighted_score
-            total_weight += factor_config['weight']
+        weighted_sum += weighted_score
+        total_weight += factor_config['weight']
 
-    # Calculate final score
-    if total_weight > 0:
-        final_score = weighted_sum / total_weight
-    else:
-        final_score = 0.0
+    final_score = (weighted_sum / total_weight) if total_weight > 0 else 0.0
 
     return {
         'score': round(final_score, 2),
         'components': component_scores,
-        'dimension': OCHDimension.WORK_RELATED.value,
+        'dimension': dimension.value,
         'interpretation': get_och_interpretation(final_score, config),
         'data_completeness': total_weight
     }
@@ -498,36 +475,11 @@ def generate_och_score_reasoning(
                     else:
                         work_factors.append(f"On-call responsibility load ({display_score:.1f} points)")
 
-                elif factor_name == 'deployment_frequency':
-                    # Include severity breakdown in critical production incident frequency
-                    if severity_dist:
-                        severity_breakdown = []
-                        total_incidents = sum(severity_dist.values())
-                        for severity, count in severity_dist.items():
-                            if count > 0:
-                                severity_breakdown.append(f"{count} {severity}")
-                        if severity_breakdown:
-                            severity_text = ", ".join(severity_breakdown)
-                            work_factors.append(f"Critical production incident frequency: {severity_text} ({display_score:.1f} points total for {total_incidents} incidents)")
-                        else:
-                            work_factors.append(f"Critical production incident frequency ({display_score:.1f} points)")
-                    else:
-                        work_factors.append(f"Critical production incident frequency ({display_score:.1f} points)")
-
-                elif factor_name == 'pr_frequency':
-                    work_factors.append(f"Incident severity-weighted workload ({display_score:.1f} points)")
-
                 elif factor_name == 'sprint_completion':
                     work_factors.append(f"Consecutive days with incidents ({display_score:.1f} points)")
 
                 elif factor_name == 'alert_health':
                     work_factors.append(f"Alert health score - night-time, escalations, retriggered issues ({display_score:.1f} points)")
-
-                elif factor_name == 'meeting_load':
-                    work_factors.append(f"Incident response meeting load ({display_score:.1f} points)")
-
-                elif factor_name == 'code_review_speed':
-                    work_factors.append(f"Code review speed pressure ({display_score:.1f} points)")
 
 
     # Output organized factors with clear headers
@@ -575,11 +527,7 @@ def get_structured_och_factors(
         'after_hours_activity': 'After-hours activity',
         'oncall_burden': 'On-call load',
         'alert_health': 'Alert health & burden',
-        'deployment_frequency': 'Incident frequency',
-        'pr_frequency': 'Severity-weighted workload',
         'sprint_completion': 'Consecutive incident days',
-        'meeting_load': 'Meeting load',
-        'code_review_speed': 'Review speed pressure'
     }
 
     def extract_factors(result: Dict[str, Any], dimension: str) -> List[Dict[str, Any]]:
@@ -587,6 +535,12 @@ def get_structured_och_factors(
         factors = []
         components = result.get('components', {})
         total_weight = result.get('data_completeness', 0)
+        config = OCHConfig()
+        dimension_weight = (
+            config.DIMENSION_WEIGHTS[OCHDimension.PERSONAL]
+            if dimension == 'personal'
+            else config.DIMENSION_WEIGHTS[OCHDimension.WORK_RELATED]
+        )
 
         if total_weight == 0:
             total_weight = sum(c.get('weight', 0) for c in components.values())
@@ -597,10 +551,11 @@ def get_structured_och_factors(
                 # Calculate contribution to the dimension score
                 contribution = weighted_score / total_weight if total_weight > 0 else 0
 
-                # Calculate percentage of total OCH score
-                # Composite score is average of personal and work scores (50/50 weight)
-                # So each dimension contributes 50% to the total
-                percentage = (contribution / composite_score * 100 * 0.5) if composite_score > 0 else 0
+                percentage = (
+                    (contribution * dimension_weight) / composite_score * 100
+                    if composite_score > 0
+                    else 0
+                )
 
                 factors.append({
                     'key': factor_name,
@@ -655,8 +610,8 @@ def validate_factor_consistency(personal_result: Dict, work_result: Dict, raw_me
 
     incident_related_work = sum([
         work_components.get('oncall_burden', {}).get('weighted_score', 0),
-        work_components.get('pr_frequency', {}).get('weighted_score', 0),
-        work_components.get('deployment_frequency', {}).get('weighted_score', 0)
+        work_components.get('sprint_completion', {}).get('weighted_score', 0),
+        work_components.get('alert_health', {}).get('weighted_score', 0)
     ])
 
     total_incident_attribution = incident_related_personal + incident_related_work

--- a/backend/app/services/ai_burnout_analyzer.py
+++ b/backend/app/services/ai_burnout_analyzer.py
@@ -372,7 +372,6 @@ class AIBurnoutAnalyzerService:
                     "email": member_email,
                     "user_id": member.get("user_id"),
                     "health_score": member.get("och_score") if member.get("och_score") is not None else member.get("burnout_score", 0),
-                    "scoring_type": "OCH" if member.get("och_score") is not None else "Legacy",
                     "incident_count": len(member.get("incidents", []))
                 })
 
@@ -633,15 +632,12 @@ class AIBurnoutAnalyzerService:
             avg_och_score = sum(och_scores) / len(och_scores)
             avg_legacy_score = 0  # Not used but defined for consistency
             using_och = True
-            # For display, convert OCH to health score (100 - OCH score)
-            overall_health_score = round(100 - avg_och_score, 1)
             avg_stress_display = round(avg_och_score, 1)
             trajectory_score = avg_och_score
         else:
             avg_legacy_score = sum(legacy_scores) / len(legacy_scores) if legacy_scores else 0
             avg_och_score = 0  # Not used but defined for consistency
             using_och = False
-            overall_health_score = round(100 - (avg_legacy_score * 10), 1)
             avg_stress_display = round(avg_legacy_score, 2)
             trajectory_score = avg_legacy_score * 10  # Convert to 0-100 scale
 
@@ -670,7 +666,6 @@ class AIBurnoutAnalyzerService:
 
         return {
             "urgency_level": urgency_level,
-            "overall_health_score": overall_health_score,
             "primary_concern": primary_concern,
             "key_metrics": {
                 "total_team_incidents": total_incidents,

--- a/backend/app/services/github_only_burnout_analyzer.py
+++ b/backend/app/services/github_only_burnout_analyzer.py
@@ -646,7 +646,6 @@ class GitHubOnlyBurnoutAnalyzer:
             return {
                 "overall_score": 5.0,
                 "risk_distribution": {"low": 0, "medium": 0, "high": 0, "critical": 0},
-                "average_burnout_score": 0.0,
                 "health_status": "unknown",
                 "members_at_risk": 0,
                 "confidence_level": "low"
@@ -691,7 +690,6 @@ class GitHubOnlyBurnoutAnalyzer:
         return {
             "overall_score": round(health_score, 2),
             "risk_distribution": risk_counts,
-            "average_burnout_score": round(avg_burnout, 2),
             "health_status": health_status,
             "members_at_risk": risk_counts["high"] + risk_counts["medium"],
             "confidence_level": confidence_label,

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -935,7 +935,9 @@ class UnifiedBurnoutAnalyzer:
 
             # Calculate period summary for consistent UI display
             team_overall_score = team_health.get("overall_score", 0.0)  # Already on 0-100 scale
-            period_average_score = team_overall_score  # No conversion needed
+            period_average_score = team_overall_score  # Compatibility field
+            period_risk_score_100 = team_health.get("risk_score_100", team_overall_score)
+            period_health_score_100 = team_health.get("health_score_100", max(0.0, 100.0 - period_risk_score_100))
             
             logger.info(f"Period summary calculation: team_overall_score={team_overall_score}, period_average_score={period_average_score}")
             logger.info(f"Team health keys: {list(team_health.keys()) if team_health else 'None'}")
@@ -1000,6 +1002,8 @@ class UnifiedBurnoutAnalyzer:
                 "raw_incident_data": slim_incidents(incidents),  # Store slimmed incident data (96% size reduction)
                 "period_summary": {
                     "average_score": round(period_average_score, 2),
+                    "average_risk_score_100": round(period_risk_score_100, 2),
+                    "average_health_score_100": round(period_health_score_100, 2),
                     "days_analyzed": time_range_days,
                     "total_days_with_data": len([d for d in daily_trends if d.get("incident_count", 0) > 0])
                 }
@@ -3376,6 +3380,10 @@ class UnifiedBurnoutAnalyzer:
             logger.warning(f"🏥 TEAM_HEALTH: No member analyses provided, returning neutral baseline")
             return {
                 "overall_score": 6.5,  # Neutral baseline if no data (not perfect health)
+                "overall_score_semantics": "health_10_compat",
+                "risk_score_100": 35.0,
+                "health_score_100": 65.0,
+                "average_risk_score_100": 35.0,
                 "risk_distribution": {"low": 0, "medium": 0, "high": 0, "critical": 0},
                 "average_health_score": 0,
                 "health_status": "fair",
@@ -3420,11 +3428,15 @@ class UnifiedBurnoutAnalyzer:
             # OCH scoring (0-100 where higher = more health risk)
             # Store raw OCH score as overall_score for frontend consumption
             overall_score = avg_score
+            risk_score_100 = max(0.0, min(100.0, avg_score))
+            health_score_100 = max(0.0, 100.0 - risk_score_100)
             logger.info(f"Using raw OCH score as overall_score: {overall_score}")
         else:
             # Legacy scoring - convert 0-10 health risk to 0-10 health scale (inverse)
             overall_score = 10 - avg_score
             overall_score = max(0, overall_score)
+            risk_score_100 = max(0.0, min(100.0, avg_score * 10.0))
+            health_score_100 = max(0.0, 100.0 - risk_score_100)
             logger.info(f"Using legacy health calculation: health_risk={avg_score} -> health={overall_score}")
         
         # Determine health status based on scoring method
@@ -3455,7 +3467,11 @@ class UnifiedBurnoutAnalyzer:
 
         return {
             "overall_score": round(overall_score, 2),
+            "overall_score_semantics": "risk_100" if using_och else "health_10_compat",
             "scoring_method": "OCH" if using_och else "Legacy",
+            "risk_score_100": round(risk_score_100, 2),
+            "health_score_100": round(health_score_100, 2),
+            "average_risk_score_100": round(risk_score_100, 2),
             "risk_distribution": risk_dist,
             "average_health_score": round(avg_score, 2),
             "health_status": health_status,
@@ -4639,9 +4655,15 @@ class UnifiedBurnoutAnalyzer:
                 else:
                     after_hours_percentage = 0
 
+                health_score_100 = round(max(0.0, min(100.0, daily_score * 10)), 1)
+                risk_score_100 = round(max(0.0, min(100.0, 100.0 - health_score_100)), 1)
+
                 daily_trends.append({
                     "date": date_str,
                     "overall_score": round(daily_score, 2),  # Keep as 0-10 scale (SimpleBurnoutAnalyzer approach)
+                    "overall_score_semantics": "health_10_compat",
+                    "health_score_100": health_score_100,
+                    "risk_score_100": risk_score_100,
                     "average_health_score": team_health.get("average_health_score", 0.0) if team_health else 0.0,
                     "incident_count": incident_count,
                     "severity_weighted_count": round(severity_weighted, 1),
@@ -4657,7 +4679,7 @@ class UnifiedBurnoutAnalyzer:
                     "members_at_risk": members_at_risk,
                     "total_members": total_members,
                     "health_status": health_status,
-                    "health_percentage": round(daily_score * 10, 1),  # Convert to percentage for display
+                    "health_percentage": health_score_100,  # Convert to percentage for display
                     # 🔍 DEBUG: Add penalty breakdown for debugging
                     "debug_penalties": {
                         "baseline": 8.7,
@@ -5298,6 +5320,20 @@ class UnifiedBurnoutAnalyzer:
             logger.error(f"JIRA CORRELATION: Error correlating Jira data: {e}")
             return members
 
+    def _apply_monotonic_och_overlay(self, original_och: float, overlay_och: float) -> tuple[float, float]:
+        """
+        Apply a monotonic 0-100 overlay score onto an existing OCH risk score.
+
+        The overlay can only increase risk and fills some of the remaining
+        headroom to 100 based on its magnitude.
+        """
+        original_och = max(0.0, min(100.0, float(original_och or 0.0)))
+        overlay_och = max(0.0, min(100.0, float(overlay_och or 0.0)))
+        final_och = original_och + (100.0 - original_och) * (overlay_och / 100.0)
+        final_och = max(original_och, min(100.0, final_och))
+        added_risk = final_och - original_och
+        return final_och, added_risk
+
     def _recalculate_burnout_with_jira(self, members: List[Dict[str, Any]], metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Recalculate OCH scores incorporating Jira ticket workload data.
@@ -5331,17 +5367,10 @@ class UnifiedBurnoutAnalyzer:
                     jira_och_contribution = self._calculate_jira_och_contribution(jira_tickets)
                     jira_och_contribution = max(0.0, min(100.0, jira_och_contribution))
 
-                    # Combine using "headroom" model:
-                    # final = original + (100 - original) * (jira / 100)
-                    # - If jira = 0 → no change
-                    # - If jira = 100 → jump to 100
-                    # - Always >= original_och, <= 100
-                    final_och = original_och + (100.0 - original_och) * (jira_och_contribution / 100.0)
-
-                    # Just in case of any float weirdness, clamp again
-                    final_och = max(original_och, min(100.0, final_och))
-
-                    jira_added_risk = final_och - original_och
+                    final_och, jira_added_risk = self._apply_monotonic_och_overlay(
+                        original_och,
+                        jira_och_contribution,
+                    )
                     updated_member["och_score"] = round(final_och, 2)
 
                     logger.info(
@@ -5698,11 +5727,10 @@ class UnifiedBurnoutAnalyzer:
                     linear_och_contribution = self._calculate_linear_och_contribution(linear_issues)
                     linear_och_contribution = max(0.0, min(100.0, linear_och_contribution))
 
-                    # Combine using "headroom" model (same as Jira)
-                    final_och = original_och + (100.0 - original_och) * (linear_och_contribution / 100.0)
-                    final_och = max(original_och, min(100.0, final_och))
-
-                    linear_added_risk = final_och - original_och
+                    final_och, linear_added_risk = self._apply_monotonic_och_overlay(
+                        original_och,
+                        linear_och_contribution,
+                    )
                     updated_member["och_score"] = round(final_och, 2)
 
                     issue_count = len(linear_issues)

--- a/backend/app/services/unified_burnout_analyzer.py
+++ b/backend/app/services/unified_burnout_analyzer.py
@@ -3385,7 +3385,6 @@ class UnifiedBurnoutAnalyzer:
                 "health_score_100": 65.0,
                 "average_risk_score_100": 35.0,
                 "risk_distribution": {"low": 0, "medium": 0, "high": 0, "critical": 0},
-                "average_health_score": 0,
                 "health_status": "fair",
                 "members_at_risk": 0
             }
@@ -3473,7 +3472,6 @@ class UnifiedBurnoutAnalyzer:
             "health_score_100": round(health_score_100, 2),
             "average_risk_score_100": round(risk_score_100, 2),
             "risk_distribution": risk_dist,
-            "average_health_score": round(avg_score, 2),
             "health_status": health_status,
             "members_at_risk": risk_dist["high"] + risk_dist["critical"]
         }
@@ -4664,7 +4662,6 @@ class UnifiedBurnoutAnalyzer:
                     "overall_score_semantics": "health_10_compat",
                     "health_score_100": health_score_100,
                     "risk_score_100": risk_score_100,
-                    "average_health_score": team_health.get("average_health_score", 0.0) if team_health else 0.0,
                     "incident_count": incident_count,
                     "severity_weighted_count": round(severity_weighted, 1),
                     "after_hours_count": after_hours_count,
@@ -4679,7 +4676,6 @@ class UnifiedBurnoutAnalyzer:
                     "members_at_risk": members_at_risk,
                     "total_members": total_members,
                     "health_status": health_status,
-                    "health_percentage": health_score_100,  # Convert to percentage for display
                     # 🔍 DEBUG: Add penalty breakdown for debugging
                     "debug_penalties": {
                         "baseline": 8.7,

--- a/backend/tests/test_incident_metrics.py
+++ b/backend/tests/test_incident_metrics.py
@@ -357,23 +357,18 @@ class TestOCHMetricMapping(unittest.TestCase):
         """Test that OCH metric names are correct."""
         och_metrics = {
             'work_hours_trend': 0,
-            'weekend_work': 0,
             'after_hours_activity': 0,
             'sleep_quality_proxy': 0,
             'sprint_completion': 0,
-            'code_review_speed': 0,
-            'pr_frequency': 0,
-            'deployment_frequency': 0,
-            'meeting_load': 0,
+            'alert_health': 0,
             'oncall_burden': 0
         }
 
         # Verify all expected OCH metrics are present
         expected_metrics = [
-            'work_hours_trend', 'weekend_work', 'after_hours_activity',
+            'work_hours_trend', 'after_hours_activity',
             'sleep_quality_proxy', 'sprint_completion',
-            'code_review_speed', 'pr_frequency', 'deployment_frequency',
-            'meeting_load', 'oncall_burden'
+            'alert_health', 'oncall_burden'
         ]
 
         for metric in expected_metrics:
@@ -382,8 +377,7 @@ class TestOCHMetricMapping(unittest.TestCase):
     def test_och_personal_burnout_factors(self):
         """Test OCH personal burnout factor mapping."""
         # Personal burnout factors derived from incidents:
-        # - work_hours_trend: incidents_per_week
-        # - weekend_work: after_hours_percentage
+        # - work_hours_trend: task load proxy
         # - after_hours_activity: after_hours_percentage
         # - sleep_quality_proxy: severity_weighted_per_week
 
@@ -394,42 +388,31 @@ class TestOCHMetricMapping(unittest.TestCase):
         # Simplified calculation (actual uses tiered scaling)
         personal_factors = {
             'work_hours_trend': incidents_per_week,
-            'weekend_work': after_hours_pct * 100,  # Convert to percentage
             'after_hours_activity': after_hours_pct * 100,
             'sleep_quality_proxy': severity_weighted_per_week
         }
 
         self.assertGreater(personal_factors['work_hours_trend'], 0)
-        self.assertGreater(personal_factors['weekend_work'], 0)
         self.assertGreater(personal_factors['after_hours_activity'], 0)
 
     def test_och_work_related_factors(self):
         """Test OCH work-related burnout factor mapping."""
         # Work-related factors derived from incidents:
-        # - sprint_completion: avg_response_time_minutes
-        # - code_review_speed: avg_response_time_minutes
-        # - pr_frequency: incidents_per_week
-        # - deployment_frequency: critical_incidents
-        # - meeting_load: incidents_per_week
+        # - sprint_completion: consecutive incident days / sustained load proxy
         # - oncall_burden: severity_weighted_per_week
+        # - alert_health: alert burden and quality proxy
 
-        incidents_per_week = 5.0
-        avg_response_minutes = 30.0
-        critical_incidents = 2
         severity_weighted_per_week = 10.0
 
         work_factors = {
-            'sprint_completion': avg_response_minutes,
-            'code_review_speed': avg_response_minutes,
-            'pr_frequency': incidents_per_week,
-            'deployment_frequency': critical_incidents,
-            'meeting_load': incidents_per_week,
-            'oncall_burden': severity_weighted_per_week
+            'sprint_completion': 3.0,
+            'oncall_burden': severity_weighted_per_week,
+            'alert_health': 45.0,
         }
 
         self.assertGreater(work_factors['sprint_completion'], 0)
-        self.assertGreater(work_factors['pr_frequency'], 0)
-        self.assertGreater(work_factors['deployment_frequency'], 0)
+        self.assertGreater(work_factors['oncall_burden'], 0)
+        self.assertGreater(work_factors['alert_health'], 0)
 
 
 class TestTimezoneConversion(unittest.TestCase):

--- a/backend/tests/test_och_calculations.py
+++ b/backend/tests/test_och_calculations.py
@@ -73,11 +73,12 @@ class TestOCHConfig(unittest.TestCase):
         self.assertIn('sleep_quality_proxy', self.config.PERSONAL_BURNOUT_FACTORS)
         self.assertIn('work_hours_trend', self.config.PERSONAL_BURNOUT_FACTORS)
 
-    def test_work_related_burnout_has_two_factors(self):
-        """Test that work-related burnout has exactly 2 factors."""
-        self.assertEqual(len(self.config.WORK_RELATED_BURNOUT_FACTORS), 2)
+    def test_work_related_burnout_has_three_factors(self):
+        """Test that work-related burnout has exactly 3 factors."""
+        self.assertEqual(len(self.config.WORK_RELATED_BURNOUT_FACTORS), 3)
         self.assertIn('oncall_burden', self.config.WORK_RELATED_BURNOUT_FACTORS)
         self.assertIn('sprint_completion', self.config.WORK_RELATED_BURNOUT_FACTORS)
+        self.assertIn('alert_health', self.config.WORK_RELATED_BURNOUT_FACTORS)
 
 
 class TestPersonalBurnoutCalculation(unittest.TestCase):
@@ -173,7 +174,8 @@ class TestWorkRelatedBurnoutCalculation(unittest.TestCase):
         # Use metrics that match current OCH config factors
         metrics = {
             'oncall_burden': 50.0,       # on-call load (scale_max=100)
-            'sprint_completion': 5.0     # consecutive incident days (scale_max=7)
+            'sprint_completion': 5.0,    # consecutive incident days (scale_max=7)
+            'alert_health': 40.0         # alert burden and quality (scale_max=100)
         }
 
         result = calculate_work_related_burnout(metrics, self.config)
@@ -187,8 +189,8 @@ class TestWorkRelatedBurnoutCalculation(unittest.TestCase):
         self.assertGreaterEqual(result['score'], 0)
         self.assertLessEqual(result['score'], 150)
 
-        # Should have all 2 components
-        self.assertEqual(len(result['components']), 2)
+        # Should have all 3 components
+        self.assertEqual(len(result['components']), 3)
 
         # Dimension should be correct
         self.assertEqual(result['dimension'], OCHDimension.WORK_RELATED.value)
@@ -197,7 +199,8 @@ class TestWorkRelatedBurnoutCalculation(unittest.TestCase):
         """Test work-related burnout calculation with high stress indicators."""
         metrics = {
             'oncall_burden': 120.0,      # Exceeds scale_max of 100
-            'sprint_completion': 10.0    # Exceeds scale_max of 7
+            'sprint_completion': 10.0,   # Exceeds scale_max of 7
+            'alert_health': 130.0        # Exceeds scale_max of 100
         }
 
         result = calculate_work_related_burnout(metrics, self.config)

--- a/backend/tests/test_unified_burnout_analyzer_integration.py
+++ b/backend/tests/test_unified_burnout_analyzer_integration.py
@@ -1114,12 +1114,9 @@ class TestOffHoursContribution:
 
         # Moderate work-related factors
         work_metrics = {
-            'sprint_completion': 25,
-            'code_review_speed': 30,
-            'pr_frequency': 40,
-            'deployment_frequency': 35,
-            'meeting_load': 25,
-            'oncall_burden': 50
+            'sprint_completion': 7,
+            'oncall_burden': 50,
+            'alert_health': 60,
         }
 
         personal_result = calculate_personal_burnout(personal_metrics)

--- a/backend/tests/test_unified_burnout_analyzer_integration.py
+++ b/backend/tests/test_unified_burnout_analyzer_integration.py
@@ -418,7 +418,7 @@ class TestCalculationMethods:
         # Check correct key names
         assert "overall_score" in result
         assert "scoring_method" in result
-        assert "average_health_score" in result  # NOT "average_burnout"
+        assert "average_risk_score_100" in result
         assert "health_status" in result
         assert "risk_distribution" in result
         assert "members_at_risk" in result

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -209,8 +209,6 @@ function DashboardContent() {
 
   // helpers
   getTrendIcon,
-  getRiskColor,
-  getProgressColor,
   getAnalysisStages,
   getAnalysisDescription,
 
@@ -1177,8 +1175,6 @@ function DashboardContent() {
               <TeamMembersList
                 currentAnalysis={currentAnalysis}
                 setSelectedMember={setSelectedMember}
-                getRiskColor={getRiskColor}
-                getProgressColor={getProgressColor}
                 connectedIntegrations={connectedIntegrations}
               />
             </>

--- a/frontend/src/components/dashboard/GitHubAllMetricsPopup.tsx
+++ b/frontend/src/components/dashboard/GitHubAllMetricsPopup.tsx
@@ -15,6 +15,7 @@ import {
   getRemainingTagCount,
   getTagColorClasses
 } from '@/lib/githubMetricUtils'
+import { getRiskScore100FromMember } from '@/lib/scoring'
 
 interface GitHubAllMetricsPopupProps {
   isOpen: boolean
@@ -37,7 +38,7 @@ export default function GitHubAllMetricsPopup({
       id: member.user_id || '',
       name: member.user_name || 'Unknown',
       email: member.user_email || '',
-      burnoutScore: member.och_score || 0,
+      healthScore: getRiskScore100FromMember(member),
       riskLevel: (member.risk_level || 'low') as 'high' | 'medium' | 'low',
       trend: 'stable' as const,
       incidentsHandled: member.incident_count || 0,

--- a/frontend/src/components/dashboard/HealthTrendsChart.tsx
+++ b/frontend/src/components/dashboard/HealthTrendsChart.tsx
@@ -3,6 +3,7 @@
 import React from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from "recharts"
+import { getRiskColor, getRiskScore100FromTrend, getRiskStatusLabel } from "@/lib/scoring"
 
 interface HealthTrendsChartProps {
   currentAnalysis: any
@@ -23,31 +24,21 @@ function getCardDescription(currentAnalysis: any, historicalTrends: any): string
   return "No daily trend data available for this analysis"
 }
 
-function getRiskLevel(ochScore: number): string {
-  if (ochScore < 25) return 'healthy'
-  if (ochScore < 50) return 'fair'
-  if (ochScore < 75) return 'poor'
-  return 'critical'
-}
-
 function getBarColor(entry: any): string {
   if (!entry.hasRealData) return '#E5E7EB'
-  if (entry.score < 25) return '#10B981'
-  if (entry.score < 50) return '#F59E0B'
-  if (entry.score < 75) return '#F97316'
-  return '#EF4444'
+  return getRiskColor(entry.score)
 }
 
 function transformDailyTrends(dailyTrends: any[]): any[] {
   return dailyTrends.map((trend: any, index: number) => {
     const incidentCount = trend.incident_count || trend.analysis_count || 0
     const hasRealData = incidentCount > 0
-    const ochScore = 100 - Math.round(trend.overall_score * 10)
+    const ochScore = Math.round(getRiskScore100FromTrend(trend))
 
     const entry = {
       date: new Date(trend.date).toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' }),
       score: hasRealData ? Math.max(0, Math.min(100, ochScore)) : 0,
-      riskLevel: hasRealData ? getRiskLevel(ochScore) : null,
+      riskLevel: hasRealData ? getRiskStatusLabel(ochScore).toLowerCase() : null,
       membersAtRisk: hasRealData ? trend.members_at_risk : null,
       totalMembers: hasRealData ? trend.total_members : null,
       healthStatus: hasRealData ? trend.health_status : null,

--- a/frontend/src/components/dashboard/MemberDetailModal.tsx
+++ b/frontend/src/components/dashboard/MemberDetailModal.tsx
@@ -15,6 +15,7 @@ import { UserIncidentCard } from "@/components/dashboard/UserIncidentCard"
 import { SurveyResultsCard } from "@/components/dashboard/SurveyResultsCard"
 import { TicketingCard } from "@/components/dashboard/TicketingCard"
 import { UserAlertsCard } from "@/components/dashboard/UserAlertsCard"
+import { getRiskScore100FromDailyHealth, getRiskScore100FromMember } from "@/lib/scoring"
 
 // OCH risk level helpers
 function getOCHRiskInfo(score: number | undefined | null): { level: string; label: string } {
@@ -90,7 +91,7 @@ function IndividualDailyHealthChart({ memberData, analysisId, currentAnalysis }:
         if (result.status === 'success' && result.data?.daily_health) {
           const formattedData = result.data.daily_health.map((day: any) => {
             const has_data = day.has_data !== undefined ? day.has_data : day.incident_count > 0;
-            const health_score = day.health_score;
+            const health_score = getRiskScore100FromDailyHealth(day);
 
             // Calculate fill color based on health score and has_data
             const fill = !has_data ? '#D1D5DB' :
@@ -385,7 +386,7 @@ export function MemberDetailModal({
               <div className="mt-4 space-y-6">
                 {/* Overall Risk Level - Always shown first */}
                 {(() => {
-                  const score = memberData?.och_score
+                  const score = getRiskScore100FromMember(memberData)
                   const scoreNum = score !== undefined ? Math.round(score) : null
                   const riskInfo = getOCHRiskInfo(score)
                   const barColor = scoreNum === null ? 'bg-neutral-300'

--- a/frontend/src/components/dashboard/ObjectiveDataCard.tsx
+++ b/frontend/src/components/dashboard/ObjectiveDataCard.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Info, TrendingUp, TrendingDown, Minus } from "lucide-react"
+import { getRiskScore100FromTrend } from "@/lib/scoring"
 
 interface ObjectiveDataCardProps {
   currentAnalysis: any
@@ -56,7 +57,7 @@ const METRIC_CONFIG: Record<string, MetricConfig> = {
     dataKey: "dailyScore",
     weeklyDataKey: "riskLevel",
     showMeanLine: true,
-    transformer: (trend: any) => Math.max(0, Math.min(100, 100 - Math.round(trend.overall_score * 10)))
+    transformer: (trend: any) => getRiskScore100FromTrend(trend)
   },
   incident_load: {
     label: "Incident Count",
@@ -117,10 +118,6 @@ function formatDateShort(date: Date): string {
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
-function calculateRiskLevel(overallScore: number): number {
-  return Math.max(0, Math.min(100, 100 - Math.round((overallScore || 0) * 10)))
-}
-
 function aggregateToWeekly(dailyData: any[]): any[] {
   if (!dailyData || dailyData.length === 0) return []
 
@@ -138,7 +135,7 @@ function aggregateToWeekly(dailyData: any[]): any[] {
       const dayCount = days.length
       const teamSize = days[0]?.total_members || 1
 
-      const avgRiskLevel = days.reduce((sum, d) => sum + calculateRiskLevel(d.overall_score), 0) / dayCount
+      const avgRiskLevel = days.reduce((sum, d) => sum + getRiskScore100FromTrend(d), 0) / dayCount
       const totalIncidents = days.reduce((sum, d) => sum + (d.incident_count || 0), 0)
       const avgAfterHours = days.reduce((sum, d) => sum + (d.after_hours_percentage || 0), 0) / dayCount
       const avgSeverityWeighted = days.reduce((sum, d) => sum + (d.severity_weighted_count || 0), 0) / dayCount

--- a/frontend/src/components/dashboard/TeamHealthOverview.tsx
+++ b/frontend/src/components/dashboard/TeamHealthOverview.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { AIInsightsCard } from "./insights/AIInsightsCard"
+import { getRiskScore100FromMember, getRiskScore100FromTeamHealth, getRiskScore100FromTrend, getRiskStatusDescription, getRiskStatusLabel } from "@/lib/scoring"
 
 interface TeamHealthOverviewProps {
   currentAnalysis: any
@@ -31,8 +32,8 @@ function calculateTeamOCHScore(currentAnalysis: any): number | null {
   if (!members || members.length === 0) return null
 
   const ochScores = members
-    .map((m: any) => m.och_score)
-    .filter((s: any) => s !== undefined && s !== null && s > 0)
+    .map((m: any) => getRiskScore100FromMember(m))
+    .filter((s: any) => s > 0)
 
   if (ochScores.length === 0) return null
   return Math.round(ochScores.reduce((a: number, b: number) => a + b, 0) / ochScores.length)
@@ -44,8 +45,8 @@ function getHealthPercentage(currentAnalysis: any, historicalTrends: any): numbe
 
   if (onCallMembers.length > 0) {
     const ochScores = onCallMembers
-      .map((m: any) => m.och_score)
-      .filter((s: any) => s !== undefined && s !== null)
+      .map((m: any) => getRiskScore100FromMember(m))
+      .filter((s: any) => s > 0)
 
     if (ochScores.length > 0) {
       return ochScores.reduce((a: number, b: number) => a + b, 0) / ochScores.length
@@ -55,35 +56,33 @@ function getHealthPercentage(currentAnalysis: any, historicalTrends: any): numbe
   // Fallback to daily trends
   if (historicalTrends?.daily_trends?.length > 0) {
     const latestTrend = historicalTrends.daily_trends[historicalTrends.daily_trends.length - 1]
-    return latestTrend.overall_score * 10
+    return getRiskScore100FromTrend(latestTrend)
   }
   if (currentAnalysis?.analysis_data?.daily_trends?.length > 0) {
     const latestTrend = currentAnalysis.analysis_data.daily_trends[currentAnalysis.analysis_data.daily_trends.length - 1]
-    return latestTrend.overall_score * 10
+    return getRiskScore100FromTrend(latestTrend)
   }
   if (currentAnalysis?.analysis_data?.team_health) {
-    return currentAnalysis.analysis_data.team_health.overall_score * 10
+    return getRiskScore100FromTeamHealth(currentAnalysis.analysis_data.team_health)
   }
   if (currentAnalysis?.analysis_data?.team_summary) {
-    return currentAnalysis.analysis_data.team_summary.average_score * 10
+    const summary = currentAnalysis.analysis_data.team_summary
+    if (typeof summary.average_risk_score_100 === "number") return summary.average_risk_score_100
+    if (typeof summary.average_health_score_100 === "number") return 100 - summary.average_health_score_100
+    const averageScore = summary.average_score
+    if (typeof averageScore === "number") return averageScore > 10 ? averageScore : averageScore * 10
   }
   return 0
 }
 
 // Convert OCH score to health status label
 function getHealthStatusLabel(ochScore: number): string {
-  if (ochScore < 25) return 'Healthy'
-  if (ochScore < 50) return 'Fair'
-  if (ochScore < 75) return 'Poor'
-  return 'Critical'
+  return getRiskStatusLabel(ochScore)
 }
 
 // Get health status description
 function getHealthStatusDescription(ochScore: number): string {
-  if (ochScore < 25) return 'Sustainable workload'
-  if (ochScore < 50) return 'Monitor for trends'
-  if (ochScore < 75) return 'Consider intervention'
-  return 'Action needed'
+  return getRiskStatusDescription(ochScore)
 }
 
 // Tooltip show/hide helpers
@@ -195,10 +194,10 @@ export function TeamHealthOverview({
               (() => {
                 const teamOchScore = calculateTeamOCHScore(currentAnalysis)
                 const scoreValue = teamOchScore ?? (() => {
-                  if (historicalTrends?.daily_trends?.length > 0) return Math.round(historicalTrends.daily_trends[historicalTrends.daily_trends.length - 1].overall_score * 10)
-                  if (currentAnalysis?.analysis_data?.daily_trends?.length > 0) return Math.round(currentAnalysis.analysis_data.daily_trends[currentAnalysis.analysis_data.daily_trends.length - 1].overall_score * 10)
-                  if (currentAnalysis?.analysis_data?.team_health) return Math.round(currentAnalysis.analysis_data.team_health.overall_score * 10)
-                  if (currentAnalysis?.analysis_data?.team_summary) return Math.round(currentAnalysis.analysis_data.team_summary.average_score * 10)
+                  if (historicalTrends?.daily_trends?.length > 0) return Math.round(getRiskScore100FromTrend(historicalTrends.daily_trends[historicalTrends.daily_trends.length - 1]))
+                  if (currentAnalysis?.analysis_data?.daily_trends?.length > 0) return Math.round(getRiskScore100FromTrend(currentAnalysis.analysis_data.daily_trends[currentAnalysis.analysis_data.daily_trends.length - 1]))
+                  if (currentAnalysis?.analysis_data?.team_health) return Math.round(getRiskScore100FromTeamHealth(currentAnalysis.analysis_data.team_health))
+                  if (currentAnalysis?.analysis_data?.team_summary) return Math.round(getHealthPercentage(currentAnalysis, historicalTrends))
                   return null
                 })()
                 const barColor = scoreValue === null ? 'bg-neutral-300'
@@ -286,11 +285,12 @@ export function TeamHealthOverview({
                       const riskCounts = { critical: 0, high: 0, medium: 0, low: 0 };
 
                       onCallMembers.forEach((member: any) => {
-                        if (member.och_score !== undefined && member.och_score !== null) {
+                        const riskScore = getRiskScore100FromMember(member)
+                        if (riskScore > 0 || member?.och_score === 0 || member?.risk_score_100 === 0) {
                           // Use OCH scoring (0-100, higher = worse)
-                          if (member.och_score >= 75) riskCounts.critical++;
-                          else if (member.och_score >= 50) riskCounts.high++;
-                          else if (member.och_score >= 25) riskCounts.medium++;
+                          if (riskScore >= 75) riskCounts.critical++;
+                          else if (riskScore >= 50) riskCounts.high++;
+                          else if (riskScore >= 25) riskCounts.medium++;
                           else riskCounts.low++;
                         }
                         // No fallback - only count members with OCH risk levels

--- a/frontend/src/components/dashboard/TeamMembersList.tsx
+++ b/frontend/src/components/dashboard/TeamMembersList.tsx
@@ -7,6 +7,11 @@ import { Button } from "@/components/ui/button"
 import { ChevronDown, ChevronRight, Users, Loader2, TrendingUp, TrendingDown, Minus, ChevronsUp, ChevronsDown, Info } from "lucide-react"
 import { useState } from "react"
 import Image from "next/image"
+import {
+  getRiskScore100FromDailyHealth,
+  getRiskScore100FromMember,
+  hasMemberRiskScore,
+} from "@/lib/scoring"
 
 // User trend categories (5 levels)
 type UserTrend = 'significantly_worsening' | 'worsening' | 'stable' | 'improving' | 'significantly_improving'
@@ -36,7 +41,7 @@ function aggregateToWeekly(dailyData: Record<string, any>): { weekStart: string;
 
   for (const date of dates) {
     const dayData = dailyData[date]
-    const dayScore = dayData.health_score || 0
+    const dayScore = getRiskScore100FromDailyHealth(dayData)
     const weekKey = getWeekStartDate(new Date(date))
 
     const bucket = weeklyBuckets.get(weekKey) || []
@@ -159,16 +164,12 @@ function getTrendConfig(trend: UserTrend) {
 interface TeamMembersListProps {
   currentAnalysis: any
   setSelectedMember: (member: any) => void
-  getRiskColor: (riskLevel: string) => string
-  getProgressColor: (riskLevel: string) => string
   connectedIntegrations?: Set<string>
 }
 
 export function TeamMembersList({
   currentAnalysis,
   setSelectedMember,
-  getRiskColor,
-  getProgressColor,
   connectedIntegrations = new Set()
 }: TeamMembersListProps) {
   const [showMembersWithoutIncidents, setShowMembersWithoutIncidents] = useState(false);
@@ -224,12 +225,14 @@ export function TeamMembersList({
   }
 
   const handleMemberClick = (member: any, trendInfo: any) => {
+    const memberRiskScore = getRiskScore100FromMember(member)
+
     setSelectedMember({
       id: member.user_id || '',
       name: member.user_name || 'Unknown',
       email: member.user_email || '',
       avatar_url: member.avatar_url || null,
-      healthScore: member.och_score || 0,
+      healthScore: memberRiskScore,
       riskLevel: (member.risk_level || 'low') as 'high' | 'medium' | 'low',
       trend: trendInfo.trend,
       trendPercentage: trendInfo.percentage,
@@ -249,6 +252,8 @@ export function TeamMembersList({
   const renderMemberRow = (member: any, index: number) => {
     const trendInfo = calculateUserTrend(member.user_email, individualDailyData)
     const trendConfig = getTrendConfig(trendInfo.trend)
+    const memberRiskScore = getRiskScore100FromMember(member)
+    const hasRiskScore = hasMemberRiskScore(member)
 
     return (
       <tr
@@ -275,7 +280,7 @@ export function TeamMembersList({
 
         {/* Risk Level + Trend (stacked on mobile) */}
         <td className="py-2 px-2 sm:py-3 sm:px-4 md:py-3 md:px-4">
-          {member?.och_score !== undefined ? (
+          {hasRiskScore ? (
             <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-3">
               {/* Trend badge (mobile only) */}
               <div className="relative group md:hidden">
@@ -299,12 +304,12 @@ export function TeamMembersList({
                   <div
                     className="h-full rounded-full transition-all"
                     style={{
-                      width: `${member.och_score}%`,
-                      backgroundColor: getOCHProgressColor(member.och_score)
+                      width: `${memberRiskScore}%`,
+                      backgroundColor: getOCHProgressColor(memberRiskScore)
                     }}
                   />
                 </div>
-                <span className="text-sm font-medium text-neutral-700 tabular-nums">{Math.round(member.och_score)}</span>
+                <span className="text-sm font-medium text-neutral-700 tabular-nums">{Math.round(memberRiskScore)}</span>
               </div>
             </div>
           ) : (
@@ -509,25 +514,23 @@ export function TeamMembersList({
             }
             
             // Filter members with valid scores
-            const validMembers = allMembers.filter((member) => {
-              return member.och_score !== undefined && member.och_score !== null
-            })
+            const validMembers = allMembers.filter((member) => hasMemberRiskScore(member))
             
             // Separate members with incidents/health risk and those with neither
             // Include members with incidents OR OCH risk level (e.g., from Jira) in main section
             const membersWithIncidents = validMembers.filter(member =>
-              (member.incident_count || 0) > 0 || (member.och_score || 0) > 0
+              (member.incident_count || 0) > 0 || getRiskScore100FromMember(member) > 0
             )
             // Only hide members with BOTH zero incidents AND zero OCH risk level
             const membersWithoutIncidents = validMembers.filter(member =>
-              (member.incident_count || 0) === 0 && (member.och_score || 0) === 0
+              (member.incident_count || 0) === 0 && getRiskScore100FromMember(member) === 0
             )
 
             // Sort members by selected criteria
             const sortMembers = (members: any[]) => {
               if (sortBy === 'risk') {
                 // Sort by OCH risk level (higher score = higher risk)
-                return [...members].sort((a, b) => (b.och_score || 0) - (a.och_score || 0));
+                return [...members].sort((a, b) => getRiskScore100FromMember(b) - getRiskScore100FromMember(a));
               }
 
               // Sort by trend (worsening first, then stable, then improving)
@@ -547,7 +550,7 @@ export function TeamMembersList({
                 const trendComparison = (trendOrder[trendA.trend] ?? 2) - (trendOrder[trendB.trend] ?? 2);
                 // If same trend level, sort by risk level (higher risk first)
                 if (trendComparison === 0) {
-                  return (b.och_score || 0) - (a.och_score || 0);
+                  return getRiskScore100FromMember(b) - getRiskScore100FromMember(a);
                 }
                 return trendComparison;
               });

--- a/frontend/src/components/dashboard/UserObjectiveDataCard.tsx
+++ b/frontend/src/components/dashboard/UserObjectiveDataCard.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Info, TrendingUp, TrendingDown, Minus } from "lucide-react"
+import { getRiskScore100FromDailyHealth } from "@/lib/scoring"
 
 interface UserObjectiveDataCardProps {
   memberData: any
@@ -53,7 +54,7 @@ const METRIC_CONFIG: Record<string, MetricConfig> = {
     dataKey: "dailyScore",
     weeklyDataKey: "riskLevel",
     showMeanLine: true,
-    transformer: (day: any) => day.health_score || 0
+    transformer: (day: any) => getRiskScore100FromDailyHealth(day)
   },
   incident_load: {
     label: "Incident Count",
@@ -130,7 +131,7 @@ function aggregateToWeekly(dailyData: any[], config: MetricConfig): any[] {
     .map(([weekStart, days]) => {
       const dayCount = days.length
 
-      const avgRiskLevel = days.reduce((sum, d) => sum + (d.health_score || 0), 0) / dayCount
+      const avgRiskLevel = days.reduce((sum, d) => sum + getRiskScore100FromDailyHealth(d), 0) / dayCount
       const totalIncidents = days.reduce((sum, d) => sum + (d.incident_count || 0), 0)
       const totalAfterHours = days.reduce((sum, d) => sum + (d.after_hours_count || 0), 0)
       const avgSeverityWeighted = days.reduce((sum, d) => sum + (d.severity_weighted_count || 0), 0) / dayCount
@@ -234,7 +235,7 @@ export function UserObjectiveDataCard({
           const transformedData = Object.entries(dailyData)
             .map(([dateStr, dayData]: [string, any]) => ({
               date: dateStr,
-              health_score: dayData.health_score || 0,
+              health_score: getRiskScore100FromDailyHealth(dayData),
               incident_count: dayData.incident_count || 0,
               team_health: dayData.team_health || 0,
               day_name: dayData.day_name || new Date(dateStr).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }),
@@ -287,7 +288,7 @@ export function UserObjectiveDataCard({
     const chartData = dailyHealthData.map((day: any) => ({
       date: formatDateShort(new Date(day.date)),
       originalDate: day.date,
-      dailyScore: day.health_score || 0,
+      dailyScore: getRiskScore100FromDailyHealth(day),
       incidentCount: day.incident_count || 0,
       afterHoursCount: day.after_hours_count || 0,
       severityWeightedCount: day.severity_weighted_count || 0,

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -4,6 +4,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { toast } from "sonner"
 import { getValidToken, clearAuthData, redirectToLogin } from "@/lib/auth"
+import {
+  getRiskColor as getRiskFillColor,
+  getRiskLevelKey,
+  getRiskScore100FromMember,
+  getRiskScore100FromTeamHealth,
+  getRiskScore100FromTrend,
+} from "@/lib/scoring"
 
 import type {
   AnalysisResult,
@@ -2339,44 +2346,6 @@ export default function useDashboard() {
     }
   }
 
-  const getRiskColor = (riskLevel: string) => {
-    switch (riskLevel) {
-      // OCH 4-tier system
-      case "critical":
-        return "text-red-800 bg-red-100"    // Critical (75-100): Dark red
-      case "poor":
-        return "text-orange-800 bg-orange-100"     // Poor (50-74): Orange
-      case "fair":
-        return "text-yellow-800 bg-yellow-100" // Fair (25-49): Yellow
-      case "healthy":
-        return "text-green-800 bg-green-100"    // Healthy (0-24): Green
-
-      // Legacy 3-tier system fallback
-      case "high":
-        return "text-orange-800 bg-orange-100"
-      case "medium":
-        return "text-yellow-800 bg-yellow-100"
-      case "low":
-        return "text-green-800 bg-green-100"
-      default:
-        return "text-gray-800 bg-gray-100"
-    }
-  }
-
-  const getProgressColor = (riskLevel: string) => {
-    switch (riskLevel) {
-      case "high":
-        return "bg-red-500"
-      case "medium":
-        return "bg-yellow-500"
-      case "low":
-        return "bg-green-500"
-      default:
-        return "bg-gray-500"
-    }
-  }
-
-  
   const getTrendIcon = (trend?: string) => {
     switch (trend) {
       case "up":
@@ -2437,12 +2406,12 @@ export default function useDashboard() {
   const chartData = historicalTrends?.daily_trends?.length > 0 
     ? historicalTrends.daily_trends.slice(-7).map((trend: any) => ({
         date: new Date(trend.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-        score: Math.round((10 - trend.overall_score) * 10) // Convert 0-10 burnout to 0-100 health scale
+        score: Math.round(getRiskScore100FromTrend(trend))
       }))
     : currentAnalysis?.analysis_data?.team_health 
       ? [{ 
           date: "Current", 
-          score: Math.round(currentAnalysis.analysis_data.team_health.overall_score * 10) 
+          score: Math.round(getRiskScore100FromTeamHealth(currentAnalysis.analysis_data.team_health))
         }] 
       : []
   
@@ -2451,34 +2420,19 @@ export default function useDashboard() {
     const members = Array.isArray(teamAnalysis) ? teamAnalysis : teamAnalysis?.members
     return members
       ?.filter((member) => {
-        // Only include members with OCH risk levels
-        const memberWithOch = member as any;
-        return memberWithOch.och_score !== undefined && memberWithOch.och_score !== null && memberWithOch.och_score > 0
+        return getRiskScore100FromMember(member) > 0
       })
       ?.map((member) => {
-        // Use OCH scoring system (0-100 scale, higher = more health risk)
-        const score = (member as any).och_score || 0
-
-        const healthScore = Math.max(0, score);
-
-        // Official OCH 4-color system based on health score (higher = worse)
-        const getRiskFromHealthScore = (healthScore: number) => {
-          if (healthScore < 25) return { level: 'low', color: '#10b981' };      // Green - Low/minimal health risk (0-24)
-          if (healthScore < 50) return { level: 'mild', color: '#eab308' };     // Yellow - Mild health risk (25-49)
-          if (healthScore < 75) return { level: 'moderate', color: '#f97316' }; // Orange - Moderate/significant health risk (50-74)
-          return { level: 'high', color: '#dc2626' };                           // Red - High/severe health risk (75-100)
-        };
-
-        const riskInfo = getRiskFromHealthScore(healthScore);
+        const healthScore = getRiskScore100FromMember(member)
 
         return {
           name: (member.user_name || member.user_email || '').split(" ")[0],
           fullName: member.user_name || member.user_email || '',
           score: healthScore,
-          riskLevel: riskInfo.level,
+          riskLevel: getRiskLevelKey(healthScore),
           backendRiskLevel: member.risk_level, // Keep original for reference
           scoreType: 'OCH',
-          fill: riskInfo.color,
+          fill: getRiskFillColor(healthScore),
         }
       })
       ?.sort((a, b) => b.score - a.score) // Sort by score descending (highest health risk first)
@@ -2521,20 +2475,11 @@ export default function useDashboard() {
   // Members with high GitHub activity but no incidents should still be included
   // Filter members with OCH risk levels only
   const membersWithOchScores = useMemo(() => members.filter((m: any) =>
-    m?.och_score !== undefined && m?.och_score !== null && m?.och_score > 0
+    getRiskScore100FromMember(m) > 0
   ), [members]);
 
   // For backward compatibility, keep membersWithIncidents for other parts of the code
   const membersWithIncidents = members.filter((m: any) => (m?.incident_count || 0) > 0);
-
-  // Check if we have any real factors data from the API (not calculated/fake values)
-  const hasRealFactorsData = membersWithIncidents.length > 0 &&
-    membersWithIncidents.some((m: any) => m?.factors && (
-      (m.factors.after_hours !== undefined && m.factors.after_hours !== null) ||
-      (m.factors.weekend_work !== undefined && m.factors.weekend_work !== null) ||
-      (m.factors.incident_load !== undefined && m.factors.incident_load !== null) ||
-      (m.factors.response_time !== undefined && m.factors.response_time !== null)
-    ));
 
   // Use backend-calculated factors for organization-level metrics
   // Backend provides pre-calculated factors - frontend should ONLY display, never recalculate
@@ -2688,8 +2633,6 @@ return {
 
   // helpers
   getTrendIcon,
-  getRiskColor,
-  getProgressColor,
   formatRadarLabel,
   getAnalysisStages,
   getAnalysisDescription,

--- a/frontend/src/lib/scoring.ts
+++ b/frontend/src/lib/scoring.ts
@@ -1,0 +1,90 @@
+function clamp100(value: number): number {
+  return Math.max(0, Math.min(100, value))
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}
+
+export function getRiskScore100FromMember(member: any): number {
+  if (isFiniteNumber(member?.risk_score_100)) return clamp100(member.risk_score_100)
+  if (isFiniteNumber(member?.och_score)) return clamp100(member.och_score)
+  if (isFiniteNumber(member?.health_score)) return clamp100(member.health_score * 10)
+  return 0
+}
+
+export function hasMemberRiskScore(member: any): boolean {
+  return (
+    isFiniteNumber(member?.risk_score_100) ||
+    isFiniteNumber(member?.och_score) ||
+    isFiniteNumber(member?.health_score)
+  )
+}
+
+export function getRiskScore100FromTeamHealth(teamHealth: any): number {
+  if (!teamHealth) return 0
+  if (isFiniteNumber(teamHealth.risk_score_100)) return clamp100(teamHealth.risk_score_100)
+  if (isFiniteNumber(teamHealth.health_score_100)) return clamp100(100 - teamHealth.health_score_100)
+
+  const overallScore = teamHealth.overall_score
+  if (!isFiniteNumber(overallScore)) return 0
+
+  if (teamHealth.scoring_method === "OCH" || overallScore > 10) {
+    return clamp100(overallScore)
+  }
+
+  return clamp100(100 - overallScore * 10)
+}
+
+export function getRiskScore100FromTrend(trend: any): number {
+  if (!trend) return 0
+  if (isFiniteNumber(trend.risk_score_100)) return clamp100(trend.risk_score_100)
+  if (isFiniteNumber(trend.health_score_100)) return clamp100(100 - trend.health_score_100)
+
+  const overallScore = trend.overall_score
+  if (!isFiniteNumber(overallScore)) return 0
+
+  if (trend.overall_score_semantics === "risk_100" || overallScore > 10) {
+    return clamp100(overallScore)
+  }
+
+  return clamp100(100 - overallScore * 10)
+}
+
+export function getRiskScore100FromDailyHealth(day: any): number {
+  if (!day) return 0
+  if (isFiniteNumber(day.risk_score_100)) return clamp100(day.risk_score_100)
+
+  // Member daily-health payloads still use `health_score` for 0-100 risk.
+  if (isFiniteNumber(day.health_score)) return clamp100(day.health_score)
+  if (isFiniteNumber(day.health_score_100)) return clamp100(100 - day.health_score_100)
+  return 0
+}
+
+export function getRiskLevelKey(riskScore100: number): "low" | "mild" | "moderate" | "high" {
+  if (riskScore100 < 25) return "low"
+  if (riskScore100 < 50) return "mild"
+  if (riskScore100 < 75) return "moderate"
+  return "high"
+}
+
+export function getRiskColor(riskScore100: number): string {
+  if (riskScore100 < 25) return "#10B981"
+  if (riskScore100 < 50) return "#F59E0B"
+  if (riskScore100 < 75) return "#F97316"
+  return "#EF4444"
+}
+
+export function getRiskStatusLabel(riskScore100: number): "Healthy" | "Fair" | "Poor" | "Critical" {
+  if (riskScore100 < 25) return "Healthy"
+  if (riskScore100 < 50) return "Fair"
+  if (riskScore100 < 75) return "Poor"
+  return "Critical"
+}
+
+export function getRiskStatusDescription(riskScore100: number): string {
+  if (riskScore100 < 25) return "Sustainable workload"
+  if (riskScore100 < 50) return "Monitor for trends"
+  if (riskScore100 < 75) return "Consider intervention"
+  return "Action needed"
+}


### PR DESCRIPTION
## Summary
- add explicit 0-100 risk and health fields alongside legacy compatibility scores
- extract the shared OCH dimension scorer and clean stale factor references
- share Jira and Linear OCH overlay logic
- centralize frontend score interpretation and remove duplicated range conversions
- move more dashboard components onto shared scoring helpers and remove dead score UI plumbing

## Verification
- python3 -m py_compile backend/app/core/och_config.py backend/app/services/unified_burnout_analyzer.py backend/app/api/endpoints/analyses.py backend/tests/test_och_calculations.py backend/tests/test_incident_metrics.py backend/tests/test_unified_burnout_analyzer_integration.py
- uv run python -m unittest backend.tests.test_och_calculations backend.tests.test_incident_metrics -v
- npm run type-check

## Notes
- backend.tests.test_unified_burnout_analyzer_integration still requires pytest in the local environment to run here