### PR TITLE
fix: restore survey scheduler user import

### DIFF
--- a/backend/app/services/survey_scheduler.py
+++ b/backend/app/services/survey_scheduler.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_, func, or_
 import pytz
 
 from ..models.survey_schedule import SurveySchedule, UserSurveyPreference
+from ..models.user import User
 from ..models.user_correlation import UserCorrelation
 from ..models.slack_integration import SlackIntegration
 from ..models.slack_workspace_mapping import SlackWorkspaceMapping

--- a/backend/tests/test_slack_interactions.py
+++ b/backend/tests/test_slack_interactions.py
@@ -352,6 +352,13 @@ class TestSlackDMSenderValidation:
 class TestSurveySchedulerUserValidation:
     """Tests for survey scheduler user validation."""
 
+    def test_survey_scheduler_imports_required_models(self):
+        """The scheduler recipient query depends on imported ORM models."""
+        from app.services import survey_scheduler as survey_scheduler_module
+
+        assert survey_scheduler_module.User.__name__ == "User"
+        assert survey_scheduler_module.UserSurveyPreference.__name__ == "UserSurveyPreference"
+
     def test_allow_users_without_user_id_when_email_present(self):
         """
         Test that roster members without a local User record are still eligible


### PR DESCRIPTION
## Summary
- restore the missing User import used by survey recipient lookups
- add a focused regression check so the scheduler module keeps its required models available

## Verification
- python3 -m py_compile backend/app/services/survey_scheduler.py backend/tests/test_slack_interactions.py
