### PR TITLE
[codex] redirect authenticated users into the app

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,48 +1,58 @@
 import { test, expect } from '@playwright/test';
 
+const anonymousStorageState = { cookies: [], origins: [] };
+
 test.describe('Authentication Flow', () => {
-  test.skip('should show login page', async ({ page }) => {
-    // TODO: Enable this test once login UI is implemented
-    // This test expects a form element on /auth/login
+  test.describe('Public Auth Pages', () => {
+    test.use({ storageState: anonymousStorageState });
+
+    test.skip('should show login page', async ({ page }) => {
+      // TODO: Enable this test once login UI is implemented
+      // This test expects a form element on /auth/login
+      await page.goto('/auth/login');
+      await page.waitForLoadState('networkidle');
+
+      const form = page.locator('form').first();
+      await expect(form, 'Login form should be visible on /auth/login page').toBeVisible();
+
+      const inputs = form.locator('input');
+      const inputCount = await inputs.count();
+      expect(inputCount, 'Login form should have at least one input field').toBeGreaterThan(0);
+    });
+
+    test.skip('should validate required fields', async ({ page }) => {
+      // TODO: Enable this test once login validation is implemented
+      await page.goto('/auth/login');
+      await page.waitForLoadState('networkidle');
+
+      const submitButton = page.locator('button[type="submit"], button:has-text("Sign in"), button:has-text("Login")').first();
+      await expect(submitButton, 'Submit button should exist on login form').toBeVisible();
+
+      await submitButton.click();
+      await page.waitForTimeout(500);
+
+      await expect(page, 'Should remain on login page after invalid submission').toHaveURL(/.*auth\/login.*/);
+    });
+
+    test('should load auth page without errors', async ({ page }) => {
+      const response = await page.goto('/auth/login');
+
+      // Check that page loads successfully
+      expect(response?.status(), 'Auth page should return 200 status').toBe(200);
+
+      await expect(
+        page.getByRole('heading', { name: 'Sign in to On-Call Health' }),
+        'Login heading should remain visible for signed-out visitors'
+      ).toBeVisible();
+
+      // Verify page loaded (has some content)
+      const bodyText = await page.textContent('body');
+      expect(bodyText?.length, 'Page should have content').toBeGreaterThan(0);
+    });
+  });
+
+  test('should redirect authenticated users away from public auth pages', async ({ page }) => {
     await page.goto('/auth/login');
-    await page.waitForLoadState('networkidle');
-
-    const form = page.locator('form').first();
-    await expect(form, 'Login form should be visible on /auth/login page').toBeVisible();
-
-    const inputs = form.locator('input');
-    const inputCount = await inputs.count();
-    expect(inputCount, 'Login form should have at least one input field').toBeGreaterThan(0);
+    await expect(page, 'Authenticated users should be routed into the app').toHaveURL(/\/dashboard(?:[/?#]|$)/);
   });
-
-  test.skip('should validate required fields', async ({ page }) => {
-    // TODO: Enable this test once login validation is implemented
-    await page.goto('/auth/login');
-    await page.waitForLoadState('networkidle');
-
-    const submitButton = page.locator('button[type="submit"], button:has-text("Sign in"), button:has-text("Login")').first();
-    await expect(submitButton, 'Submit button should exist on login form').toBeVisible();
-
-    await submitButton.click();
-    await page.waitForTimeout(500);
-
-    await expect(page, 'Should remain on login page after invalid submission').toHaveURL(/.*auth\/login.*/);
-  });
-
-  // Example test that works with current app structure
-  test('should load auth page without errors', async ({ page }) => {
-    const response = await page.goto('/auth/login');
-
-    // Check that page loads successfully
-    expect(response?.status(), 'Auth page should return 200 status').toBe(200);
-
-    // Verify page loaded (has some content)
-    const bodyText = await page.textContent('body');
-    expect(bodyText?.length, 'Page should have content').toBeGreaterThan(0);
-  });
-
-  // Add more auth tests as you build the feature:
-  // - test('should login with valid credentials')
-  // - test('should show error with invalid credentials')
-  // - test('should redirect to dashboard after login')
 });

--- a/frontend/e2e/landing-page.spec.ts
+++ b/frontend/e2e/landing-page.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
+const anonymousStorageState = { cookies: [], origins: [] };
+
 test.describe('Landing Page', () => {
+  test.use({ storageState: anonymousStorageState });
+
   test('should load and display main heading', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -4,7 +4,11 @@ import { test, expect } from '@playwright/test';
  * Smoke tests - verify the app loads and basic functionality works
  */
 
+const anonymousStorageState = { cookies: [], origins: [] };
+
 test.describe('Smoke Tests', () => {
+  test.use({ storageState: anonymousStorageState });
+
   test('landing page has correct title', async ({ page }) => {
     await page.goto('/');
 

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -1,55 +1,58 @@
 "use client"
 
+import AuthRedirectGate from "@/components/AuthRedirectGate"
 import { Card, CardContent } from "@/components/ui/card"
 import Image from "next/image"
 import { AuthProviderButtons } from "@/components/auth-provider-buttons"
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen bg-[url(/images/landing/rootly-bg-hq.webp)] bg-cover bg-[position:50%_15%] lg:bg-[size:210%] lg:bg-[position:-1200px_-300px] p-4 sm:p-6 lg:p-8">
-      <div className="mx-auto flex min-h-[calc(100vh-2rem)] max-w-6xl items-center justify-center">
-        <Card className="w-full max-w-[32rem] border border-white/20 bg-white/12 text-white shadow-2xl backdrop-blur-xl">
-          <CardContent className="p-6 sm:p-8">
-            <div className="mb-8 flex flex-col items-center text-center">
-              <div className="flex flex-col items-center -space-y-0.5">
-                <div className="flex items-center gap-1.5">
-                  <span className="text-2xl font-normal text-white">On-Call Health</span>
-                  <Image
-                    src="/images/on-call-health-logo.svg"
-                    alt="On-Call Health"
-                    width={32}
-                    height={32}
-                    className="h-8 w-8 brightness-0 invert"
-                  />
+    <AuthRedirectGate>
+      <div className="min-h-screen bg-[url(/images/landing/rootly-bg-hq.webp)] bg-cover bg-[position:50%_15%] lg:bg-[size:210%] lg:bg-[position:-1200px_-300px] p-4 sm:p-6 lg:p-8">
+        <div className="mx-auto flex min-h-[calc(100vh-2rem)] max-w-6xl items-center justify-center">
+          <Card className="w-full max-w-[32rem] border border-white/20 bg-white/12 text-white shadow-2xl backdrop-blur-xl">
+            <CardContent className="p-6 sm:p-8">
+              <div className="mb-8 flex flex-col items-center text-center">
+                <div className="flex flex-col items-center -space-y-0.5">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-2xl font-normal text-white">On-Call Health</span>
+                    <Image
+                      src="/images/on-call-health-logo.svg"
+                      alt="On-Call Health"
+                      width={32}
+                      height={32}
+                      className="h-8 w-8 brightness-0 invert"
+                    />
+                  </div>
+                  <div className="mt-1 flex items-center gap-1.5">
+                    <span className="text-xs font-light text-white/80">Powered by</span>
+                    <Image
+                      src="/images/rootly-ai-logo-white.png"
+                      alt="Rootly"
+                      width={321}
+                      height={129}
+                      className="w-[70px]"
+                    />
+                  </div>
                 </div>
-                <div className="mt-1 flex items-center gap-1.5">
-                  <span className="text-xs font-light text-white/80">Powered by</span>
-                  <Image
-                    src="/images/rootly-ai-logo-white.png"
-                    alt="Rootly"
-                    width={321}
-                    height={129}
-                    className="w-[70px]"
-                  />
-                </div>
+                <h1 className="mt-8 text-3xl font-semibold tracking-tight text-white">
+                  Sign in to On-Call Health
+                </h1>
+                <p className="mt-3 max-w-md text-sm text-white/80 sm:text-base">
+                  Continue with your work identity provider or developer account.
+                </p>
               </div>
-              <h1 className="mt-8 text-3xl font-semibold tracking-tight text-white">
-                Sign in to On-Call Health
-              </h1>
-              <p className="mt-3 max-w-md text-sm text-white/80 sm:text-base">
-                Continue with your work identity provider or developer account.
-              </p>
-            </div>
 
-            <AuthProviderButtons
-              variant="card"
-              className="mx-auto max-w-[23.5rem]"
-              title="Choose a provider"
-              description="Google and GitHub work well for individual access. Okta is available for enterprise sign-in."
-            />
-          </CardContent>
-        </Card>
+              <AuthProviderButtons
+                variant="card"
+                className="mx-auto max-w-[23.5rem]"
+                title="Choose a provider"
+                description="Google and GitHub work well for individual access. Okta is available for enterprise sign-in."
+              />
+            </CardContent>
+          </Card>
+        </div>
       </div>
-    </div>
+    </AuthRedirectGate>
   )
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,10 @@
+import AuthRedirectGate from '@/components/AuthRedirectGate'
 import LandingPage from '@/components/landing-page'
 
 export default function Home() {
-  return <LandingPage />
+  return (
+    <AuthRedirectGate>
+      <LandingPage />
+    </AuthRedirectGate>
+  )
 }

--- a/frontend/src/components/AuthRedirectGate.tsx
+++ b/frontend/src/components/AuthRedirectGate.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Loader2 } from "lucide-react"
+import { getValidToken } from "@/lib/auth"
+
+interface AuthRedirectGateProps {
+  children: React.ReactNode
+  redirectTo?: string
+}
+
+export default function AuthRedirectGate({
+  children,
+  redirectTo = "/dashboard",
+}: AuthRedirectGateProps) {
+  const router = useRouter()
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true)
+
+  useEffect(() => {
+    const token = getValidToken()
+
+    if (token) {
+      router.replace(redirectTo)
+      return
+    }
+
+    setIsCheckingAuth(false)
+  }, [redirectTo, router])
+
+  if (isCheckingAuth) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-neutral-100">
+        <div className="flex items-center gap-3 rounded-full border border-neutral-200 bg-white px-5 py-3 text-sm font-medium text-neutral-600 shadow-sm">
+          <Loader2 className="h-4 w-4 animate-spin text-purple-700" />
+          Redirecting to your workspace...
+        </div>
+      </div>
+    )
+  }
+
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- add a small auth redirect gate for public entry pages
- send users with a valid local session straight to `/dashboard`
- keep the landing and login pages visible only for unauthenticated visitors

## Why
Authenticated users were still landing on the public home/login experience when they revisited On-Call Health. That added friction and made the app feel like it had lost their session even when a valid token was present locally.

## User impact
Users who are already signed in now go directly into the product instead of seeing the landing or login page first. Unauthenticated users still see the existing public entry flow.

## Validation
- `npm run type-check`
