### PR TITLE
[codex] remove legacy oncallburnout domains

### DIFF
--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -37,8 +37,6 @@ ALLOWED_OAUTH_ORIGINS = [
     "http://127.0.0.1:3001",
     "http://127.0.0.1:3002",
     settings.FRONTEND_URL,
-    "https://www.oncallburnout.com",
-    "https://oncallburnout.com",
     "https://oncallhealth.ai",
     "https://www.oncallhealth.ai",
     "https://testing.oncallhealth.ai",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -105,8 +105,6 @@ def get_cors_origins() -> list[str]:
 
     # Production domains
     origins.extend([
-        "https://www.oncallburnout.com",
-        "https://oncallburnout.com",
         "https://oncallhealth.ai",
         "https://www.oncallhealth.ai",
         "https://testing.oncallhealth.ai",


### PR DESCRIPTION
## Summary
- remove legacy oncallburnout.com origins from backend CORS configuration
- remove the same legacy domains from the auth OAuth allowlist

## Validation
- python3 -m py_compile backend/app/main.py backend/app/api/endpoints/auth.py