### PR TITLE
Bump postcss to >=8.5.10 (fix CVE-2026-41305 XSS)

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -33,7 +33,7 @@
         "lucide-react": "^0.577.0",
         "next": "^16.2.6",
         "next-themes": "^0.4.6",
-        "postcss": "^8",
+        "postcss": "^8.5.10",
         "react": "^19.2.6",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.6",
@@ -69,6 +69,7 @@
     "picomatch@^2.2.1": "2.3.2",
     "picomatch@^2.3.1": "2.3.2",
     "picomatch@^4.0.3": "4.0.4",
+    "postcss": "^8.5.10",
     "yaml@^2.3.4": "2.8.3",
   },
   "packages": {
@@ -1054,7 +1055,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
 
@@ -1363,8 +1364,6 @@
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "is-bun-module/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "lucide-react": "^0.577.0",
         "next": "^16.2.6",
         "next-themes": "^0.4.6",
-        "postcss": "^8",
+        "postcss": "^8.5.10",
         "react": "^19.2.6",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.6",
@@ -7625,34 +7625,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-releases": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "lucide-react": "^0.577.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
-    "postcss": "^8",
+    "postcss": "^8.5.10",
     "react": "^19.2.6",
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.6",
@@ -77,6 +77,7 @@
     "picomatch@^2.2.1": "2.3.2",
     "picomatch@^2.3.1": "2.3.2",
     "picomatch@^4.0.3": "4.0.4",
+    "postcss": "^8.5.10",
     "yaml@^2.3.4": "2.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `postcss` to `>=8.5.10` to resolve **Dependabot alert #17** / [GHSA-qx2v-qp2m-jg93](https://github.com/postcss/postcss/security/advisories/GHSA-qx2v-qp2m-jg93) / CVE-2026-41305 (medium, CVSS 6.1).
- PostCSS <8.5.10 doesn't escape `</style>` sequences when stringifying CSS, allowing XSS when user-submitted CSS is parsed and re-embedded in `<style>` tags.

## Changes
- `frontend/package.json`: direct dep `postcss: ^8` → `^8.5.10`
- `frontend/package.json`: added `postcss: ^8.5.10` to `overrides` (Next.js was pinning `8.4.31` in its own `node_modules`)
- `frontend/package-lock.json` regenerated; all postcss instances now resolve to 8.5.14

## Verification
- `npm audit` → 0 vulnerabilities
- `npm run type-check` → passes
- `npm ls postcss` shows all instances on 8.5.14