### PR TITLE
fix: bound DB connection pool to prevent server-wide exhaustion

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -205,22 +205,6 @@ async def startup_event():
     finally:
         db.close()
 
-
-@app.on_event("shutdown")
-async def shutdown_event():
-    """Dispose the database engine on graceful shutdown.
-
-    Releases all pooled connections back to PostgreSQL promptly when the
-    container stops or is redeployed, instead of leaving them to linger
-    server-side until they time out. This shrinks the window during a deploy
-    where the old and new containers both hold full pools and can push the
-    shared server over its connection limit.
-    """
-    from app.models.base import engine
-    engine.dispose()
-    logger.info("Database engine disposed on shutdown")
-
-
     # Start auto-refresh analysis scheduler — one cron job per interval cadence
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
     from apscheduler.triggers.cron import CronTrigger
@@ -248,6 +232,21 @@ async def shutdown_event():
         print("Weekly digest scheduler started (fires */30; sends Tuesday 10am per user's local timezone)")
     else:
         print("Weekly digest scheduler disabled (WEEKLY_DIGEST_ENABLED=false)")
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    """Dispose the database engine on graceful shutdown.
+
+    Releases all pooled connections back to PostgreSQL promptly when the
+    container stops or is redeployed, instead of leaving them to linger
+    server-side until they time out. This shrinks the window during a deploy
+    where the old and new containers both hold full pools and can push the
+    shared server over its connection limit.
+    """
+    from app.models.base import engine
+    engine.dispose()
+    logger.info("Database engine disposed on shutdown")
 
 
 # Include API routers

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -149,8 +149,17 @@ async def root():
 
 @app.get("/health")
 async def health():
-    """Health check endpoint."""
-    return {"status": "healthy", "service": "on-call-health"}
+    """Health check endpoint.
+
+    Includes live connection-pool utilization so saturation can be spotted from
+    monitoring before it turns into "too many clients already" errors.
+    """
+    from app.models.base import get_pool_status
+    return {
+        "status": "healthy",
+        "service": "on-call-health",
+        "db_pool": get_pool_status(),
+    }
 
 @app.get('/favicon.ico', include_in_schema=False)
 async def favicon():
@@ -195,6 +204,21 @@ async def startup_event():
         print(f"Error loading survey schedules: {str(e)}")
     finally:
         db.close()
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    """Dispose the database engine on graceful shutdown.
+
+    Releases all pooled connections back to PostgreSQL promptly when the
+    container stops or is redeployed, instead of leaving them to linger
+    server-side until they time out. This shrinks the window during a deploy
+    where the old and new containers both hold full pools and can push the
+    shared server over its connection limit.
+    """
+    from app.models.base import engine
+    engine.dispose()
+    logger.info("Database engine disposed on shutdown")
 
 
     # Start auto-refresh analysis scheduler — one cron job per interval cadence

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -4,7 +4,10 @@ Database configuration and base models.
 from sqlalchemy import create_engine, MetaData
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 # Database configuration
 DATABASE_URL = os.getenv("DATABASE_URL")
@@ -14,25 +17,99 @@ if not DATABASE_URL:
         "For local development, use PostgreSQL (e.g., postgresql://user:password@localhost/dbname)"
     )
 
-# Query timeout settings (in milliseconds)
-STATEMENT_TIMEOUT_MS = int(os.getenv("DB_STATEMENT_TIMEOUT_MS", "60000"))  # 60 seconds default
-LOCK_TIMEOUT_MS = int(os.getenv("DB_LOCK_TIMEOUT_MS", "30000"))  # 30 seconds default
 
-# Create PostgreSQL engine with increased pool limits and query timeouts
+def _int_env(name: str, default: int) -> int:
+    """Read an integer setting from the environment, falling back to a default.
+
+    Tolerant of unset/blank/invalid values so a typo in a deploy variable can
+    never crash the app at import time — it just falls back to the default.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid value for %s=%r; falling back to default %d", name, raw, default)
+        return default
+
+
+# --- Connection pool configuration -------------------------------------------
+# IMPORTANT: this application shares a single PostgreSQL server with other
+# services (notably the OnCallHealthData admin dashboard). PostgreSQL caps the
+# total number of concurrent connections via `max_connections`, so the SUM of
+# (DB_POOL_SIZE + DB_MAX_OVERFLOW) across EVERY process and service that talks
+# to the database must stay comfortably below that ceiling. Exceeding it makes
+# new connections fail with "FATAL: sorry, too many clients already".
+#
+# Budgeting rule of thumb (check the real ceiling with `SHOW max_connections;`):
+#   sum over all processes(pool_size + max_overflow) + headroom  <  max_connections
+# e.g. 2 processes here (web + worker) x (10 + 10) = 40, leaving room for the
+# admin dashboard and ad-hoc psql sessions under a typical 100-connection cap.
+#
+# Every value is environment-overridable so the pool can be retuned for a given
+# Railway/Postgres plan WITHOUT a code deploy. Defaults are deliberately
+# conservative (previously these were a hard-coded 30 + 20 = 50 per process,
+# which alone could exhaust the shared server).
+POOL_SIZE = _int_env("DB_POOL_SIZE", 10)          # persistent connections kept warm
+MAX_OVERFLOW = _int_env("DB_MAX_OVERFLOW", 10)    # extra burst connections beyond pool_size
+POOL_TIMEOUT = _int_env("DB_POOL_TIMEOUT", 30)    # seconds a request waits for a free connection
+POOL_RECYCLE = _int_env("DB_POOL_RECYCLE", 1800)  # recycle connections older than this many seconds
+
+# Query timeout settings (in milliseconds)
+STATEMENT_TIMEOUT_MS = _int_env("DB_STATEMENT_TIMEOUT_MS", 60000)  # 60 seconds default
+LOCK_TIMEOUT_MS = _int_env("DB_LOCK_TIMEOUT_MS", 30000)            # 30 seconds default
+
+# Tag every connection so it is identifiable in pg_stat_activity. This is what
+# lets you run, during an incident:
+#   SELECT application_name, count(*) FROM pg_stat_activity GROUP BY 1 ORDER BY 2 DESC;
+# and see at a glance which service is holding connections.
+APP_NAME = os.getenv("DB_APPLICATION_NAME", "oncall-health-backend")
+
+# Create PostgreSQL engine with bounded pool limits and query timeouts
 engine = create_engine(
     DATABASE_URL,
-    pool_size=30,           # Increased from 20 to 30 base connections
-    max_overflow=20,        # Allow 20 overflow connections (total 50 max)
-    pool_pre_ping=True,     # Test connections before use
-    pool_recycle=300,       # Recycle connections every 5 minutes
-    pool_timeout=60,        # Wait up to 60 seconds for connection
-    echo_pool=False,        # Set to True for debugging pool issues
+    pool_size=POOL_SIZE,
+    max_overflow=MAX_OVERFLOW,
+    pool_timeout=POOL_TIMEOUT,
+    pool_recycle=POOL_RECYCLE,
+    pool_pre_ping=True,     # transparently replace connections dropped server-side
+    pool_use_lifo=True,     # reuse the most-recently-returned connection first, so
+                            # connections in the idle tail age out and get recycled —
+                            # keeps the number of actually-open connections low under
+                            # bursty load instead of holding the full pool open
+    echo_pool=False,        # set to True (or DB_ECHO_POOL) for verbose pool debugging
     connect_args={
-        "options": f"-c statement_timeout={STATEMENT_TIMEOUT_MS} -c lock_timeout={LOCK_TIMEOUT_MS}"
-    }
+        "application_name": APP_NAME,
+        "options": f"-c statement_timeout={STATEMENT_TIMEOUT_MS} -c lock_timeout={LOCK_TIMEOUT_MS}",
+    },
+)
+
+logger.info(
+    "Database engine initialized: pool_size=%d max_overflow=%d "
+    "(max %d connections per process), pool_timeout=%ds pool_recycle=%ds application_name=%s",
+    POOL_SIZE, MAX_OVERFLOW, POOL_SIZE + MAX_OVERFLOW, POOL_TIMEOUT, POOL_RECYCLE, APP_NAME,
 )
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_pool_status() -> dict:
+    """Return current connection-pool utilization for health/debug endpoints.
+
+    `checked_out` is the number of connections currently in use; when it
+    approaches `total_capacity` the app is close to saturating its own pool.
+    """
+    pool = engine.pool
+    return {
+        "pool_size": POOL_SIZE,
+        "max_overflow": MAX_OVERFLOW,
+        "total_capacity": POOL_SIZE + MAX_OVERFLOW,
+        "checked_out": pool.checkedout(),   # connections currently handed out / in use
+        "checked_in": pool.checkedin(),     # idle connections available for reuse
+        "overflow": pool.overflow(),        # overflow connections beyond pool_size in use
+        "application_name": APP_NAME,
+    }
 
 # Base class for all models
 Base = declarative_base()

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -78,7 +78,7 @@ engine = create_engine(
                             # connections in the idle tail age out and get recycled —
                             # keeps the number of actually-open connections low under
                             # bursty load instead of holding the full pool open
-    echo_pool=False,        # set to True (or DB_ECHO_POOL) for verbose pool debugging
+    echo_pool=os.getenv("DB_ECHO_POOL", "").lower() in ("1", "true", "yes"),  # set DB_ECHO_POOL=true for verbose pool debugging
     connect_args={
         "application_name": APP_NAME,
         "options": f"-c statement_timeout={STATEMENT_TIMEOUT_MS} -c lock_timeout={LOCK_TIMEOUT_MS}",


### PR DESCRIPTION
The engine was hard-coded to pool_size=30 + max_overflow=20 (50 connections per process). With multiple processes/instances sharing a single Postgres (max_connections=100, also shared with the OnCallHealthData admin dashboard), load could push total connections past the ceiling, causing "FATAL: sorry, too many clients already" for every service — including the admin dashboard, which surfaced the error first.

Changes:
- Make all pool settings env-overridable (DB_POOL_SIZE, DB_MAX_OVERFLOW, DB_POOL_TIMEOUT, DB_POOL_RECYCLE) so the pool can be retuned without a code deploy. Conservative defaults: 10 + 10 = 20 max per process.
- pool_use_lifo=True so idle connections in the tail age out instead of staying open, keeping the actually-open count low under bursty load.
- pool_recycle 300s -> 1800s (pre_ping already guards staleness; avoids needless reconnect churn).
- Tag connections with application_name so pg_stat_activity shows which service holds connections during an incident.
- Add get_pool_status() and surface live pool utilization in /health.
- Dispose the engine on app shutdown so connections are released promptly on redeploy instead of lingering server-side.