### PR TITLE
fix: reap idle DB connections to prevent max_connections lockout

### DIFF
--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -60,6 +60,16 @@ POOL_RECYCLE = _int_env("DB_POOL_RECYCLE", 1800)  # recycle connections older th
 STATEMENT_TIMEOUT_MS = _int_env("DB_STATEMENT_TIMEOUT_MS", 60000)  # 60 seconds default
 LOCK_TIMEOUT_MS = _int_env("DB_LOCK_TIMEOUT_MS", 30000)            # 30 seconds default
 
+# Idle-connection reapers (in milliseconds). Railway Postgres has no idle
+# timeout and its TCP proxy keeps orphaned backends ESTABLISHED, so a leaked or
+# stranded connection would otherwise live forever and count against the shared
+# max_connections budget until the server is fully locked out ("FATAL: sorry,
+# too many clients already"). These make Postgres itself close such connections
+# so a leak can never saturate the server. pool_pre_ping reconnects transparently
+# when the server closes a pooled connection.
+IDLE_SESSION_TIMEOUT_MS = _int_env("DB_IDLE_SESSION_TIMEOUT_MS", 300000)          # 5 minutes
+IDLE_IN_TX_TIMEOUT_MS = _int_env("DB_IDLE_IN_TRANSACTION_TIMEOUT_MS", 60000)      # 60 seconds
+
 # Tag every connection so it is identifiable in pg_stat_activity. This is what
 # lets you run, during an incident:
 #   SELECT application_name, count(*) FROM pg_stat_activity GROUP BY 1 ORDER BY 2 DESC;
@@ -81,7 +91,12 @@ engine = create_engine(
     echo_pool=os.getenv("DB_ECHO_POOL", "").lower() in ("1", "true", "yes"),  # set DB_ECHO_POOL=true for verbose pool debugging
     connect_args={
         "application_name": APP_NAME,
-        "options": f"-c statement_timeout={STATEMENT_TIMEOUT_MS} -c lock_timeout={LOCK_TIMEOUT_MS}",
+        "options": (
+            f"-c statement_timeout={STATEMENT_TIMEOUT_MS} "
+            f"-c lock_timeout={LOCK_TIMEOUT_MS} "
+            f"-c idle_session_timeout={IDLE_SESSION_TIMEOUT_MS} "
+            f"-c idle_in_transaction_session_timeout={IDLE_IN_TX_TIMEOUT_MS}"
+        ),
     },
 )
 


### PR DESCRIPTION
## Problem

This app shares one Railway Postgres with the `on-call-health-data` admin dashboard. During an incident the server hit **`FATAL: sorry, too many clients already`** for every client — including the superuser-reserved slots — and stayed fully locked (100/100 connections) with zero slots freeing over 5+ minutes. Recovery required a manual Postgres restart.

Railway Postgres has **no idle timeout**, and its TCP proxy (`turntable.proxy.rlwy.net`) keeps orphaned backends `ESTABLISHED` even after the client process is gone, so leaked/stranded connections live forever and accumulate until the shared `max_connections` (100) is exhausted. Post-restart inspection showed this app leaving connections in `idle in transaction`, which hold a slot indefinitely.

## Fix

The engine already bounds its pool and sets `statement_timeout` / `lock_timeout`, but had **no idle reapers**. Add `idle_session_timeout` (5m) and `idle_in_transaction_session_timeout` (60s) to the libpq `options`, so Postgres itself closes idle/stranded connections and a leak can never saturate the shared server. `pool_pre_ping` already reconnects transparently when the server closes a pooled connection. Both values are env-overridable (`DB_IDLE_SESSION_TIMEOUT_MS`, `DB_IDLE_IN_TRANSACTION_TIMEOUT_MS`).

## Notes

- Prevents recurrence; does **not** clear an already-saturated server (that needs a Postgres restart).
- A parallel PR adds the same reapers to the `on-call-health-data` admin dashboard, which shares this database.