### PR TITLE
fix: pin actions to SHA in dependabot-bun-lock workflow

### DIFF
--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -13,12 +13,12 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - run: cd frontend && bun install
 


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` and `oven-sh/setup-bun` to full commit SHAs in `dependabot-bun-lock.yml`
- Org policy requires SHA-pinned actions; this was blocking all dependabot frontend PRs

## Test plan
- [ ] CI passes on this PR
- [ ] Dependabot PRs (#508, #504) should pass `update-lockfile` job after rebase